### PR TITLE
Fix tax engine models and tests

### DIFF
--- a/services/tax_engine/models.py
+++ b/services/tax_engine/models.py
@@ -4,13 +4,11 @@ from typing import Optional, Literal, List, Dict
 class Tx(BaseModel): 
     txid: str 
     date: str                 # ISO date 
-    country_code: str         # ISO-3166 alpha-2 
-    type: 
-Literal["sale","service","grant","interest","royalty","expense"] 
+    country_code: str         # ISO-3166 alpha-2
+    type: Literal["sale","service","grant","interest","royalty","expense"]
     customer_tax_id: Optional[str] = None 
     customer_is_business: bool = False 
-    category: Optional[str] = None   # para mapear a tipos con tasa 
-reducida 
+    category: Optional[str] = None   # para mapear a tipos con tasa reducida
     currency: str 
     amount_net: float 
     vat_rate: Optional[float] = None 
@@ -29,9 +27,9 @@ class WithholdingInput(BaseModel):
     jurisdiction: str 
     payee_id: str 
     payee_tin: Optional[str] = None 
-    amount_gross: float 
-    context: Dict[str,str] = Field(default_factory=dict)  # e.g., 
-{"freelance":"true","reduced":"false"} 
+    amount_gross: float
+    context: Dict[str,str] = Field(default_factory=dict)  # e.g.,
+    # {"freelance":"true","reduced":"false"}
  
 class WithholdingResult(BaseModel): 
     amount_gross: float 

--- a/services/tax_engine/tests/test_tax_engine.py
+++ b/services/tax_engine/tests/test_tax_engine.py
@@ -1,17 +1,21 @@
-from services.tax_engine.withholding import compute_withholding, 
-WithholdingInput 
+from services.tax_engine.withholding import compute_withholding, WithholdingInput
  
-def test_withholding_es_freelance_general(): 
-    inp = WithholdingInput(jurisdiction="ES", payee_id="u1", 
-amount_gross=1000.0, context={"freelance":"true"}) 
-    res = compute_withholding(inp) 
-    assert round(res.amount_withheld,2) == 150.00 
-    assert round(res.amount_net,2) == 850.00 
+def test_withholding_es_freelance_general():
+    inp = WithholdingInput(
+        jurisdiction="ES", payee_id="u1",
+        amount_gross=1000.0, context={"freelance":"true"}
+    )
+    res = compute_withholding(inp)
+    assert round(res.amount_withheld, 2) == 150.00
+    assert round(res.amount_net, 2) == 850.00
  
-def test_withholding_us_backup(): 
-    inp = WithholdingInput(jurisdiction="US", payee_id="p1", 
-amount_gross=500.0, payee_tin=None, context={"w9":"false"}) 
-    res = compute_withholding(inp) 
-    assert round(res.amount_withheld,2) == 120.00 
+def test_withholding_us_backup():
+    inp = WithholdingInput(
+        jurisdiction="US", payee_id="p1",
+        amount_gross=500.0, payee_tin=None, context={"w9":"false"}
+    )
+    res = compute_withholding(inp)
+    assert round(res.amount_withheld, 2) == 120.00
+    assert round(res.amount_net, 2) == 380.00
  
  

--- a/services/tax_engine/withholding.py
+++ b/services/tax_engine/withholding.py
@@ -1,5 +1,4 @@
-from .models import WithholdingInput, WithholdingResult 
-from typing import Tuple 
+from .models import WithholdingInput, WithholdingResult
  
 def compute_withholding(inp: WithholdingInput) -> WithholdingResult: 
     """ 
@@ -19,13 +18,13 @@ válido/consentimiento W-9
                 rate = 0.07; reason = "IRPF freelance reducido" 
             else: 
                 rate = 0.15; reason = "IRPF freelance general" 
-    elif j == "US": 
-        # backup withholding si TIN ausente/incorrecto o sin W9 
-        tin_ok = (inp.payee_tin or "").isdigit() and len(inp.payee_tin 
-or "") == 9 
-        has_w9 = inp.context.get("w9","false").lower() == "true" 
-        if not (tin_ok and has_w9): 
-            rate = 0.24; reason = "Backup withholding 26 USC §3406" 
+    elif j == "US":
+        # backup withholding si TIN ausente/incorrecto o sin W9
+        tin = inp.payee_tin or ""
+        tin_ok = tin.isdigit() and len(tin) == 9
+        has_w9 = inp.context.get("w9","false").lower() == "true"
+        if not (tin_ok and has_w9):
+            rate = 0.24; reason = "Backup withholding 26 USC §3406"
     # TODO: añadir otros países 
  
     amount_withheld = round(inp.amount_gross * rate, 2) 


### PR DESCRIPTION
## Summary
- Correct Tx model `type` annotation and comment formatting
- Refactor US TIN validation logic in withholding calculation
- Repair withholding tests and add net amount assertion

## Testing
- `PYTHONPATH=/workspace/GNEW3 pytest services/tax_engine/tests` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aa56ce19f4832697651e0de4ff0d00