### PR TITLE
fix: handle zero seed value

### DIFF
--- a/apps/api/src/routes/missions.ts
+++ b/apps/api/src/routes/missions.ts
@@ -117,7 +117,11 @@ export function registerMissionsRoutes(app: Application) {
         if (Number.isNaN(+d)) return badRequest(res, "weekStart no es una fecha válida");
       }
 
-      const s = seed ? Math.abs(parseInt(seed, 10)) || undefined : undefined;
+        let s: number | undefined;
+        if (seed !== undefined) {
+          const n = Math.abs(parseInt(seed, 10));
+          if (!Number.isNaN(n)) s = n;
+        }
 
       // Plan con feedback mínimo de ejemplo (para que la UI tenga estructura)
       const demo: FeedbackItem[] = [


### PR DESCRIPTION
## Summary
- handle 0 as a valid seed in weekly missions API

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68aa57f71d08832689623ead22f58a35