### PR TITLE
ci: simplify deploy strategy workflow

### DIFF
--- a/.github/workflows/deploy-strategy.yml
+++ b/.github/workflows/deploy-strategy.yml
@@ -5,23 +5,27 @@ on:
     inputs:
       service:
         description: "Servicio"
-        required: true
         type: string
-        default: "gateway"
+        default: gateway
       version:
         description: "Imagen tag/digest"
-        required: true
         type: string
+        required: true
       strategy:
         description: "canary|bluegreen|direct"
-        required: true
         type: choice
-        options: ["canary", "bluegreen", "direct"]
+        required: true
+        options:
+          - canary
+          - bluegreen
+          - direct
       env:
         description: "staging|prod"
-        required: true
         type: choice
-        options: ["staging", "prod"]
+        required: true
+        options:
+          - staging
+          - prod
 
 env:
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/gnew
@@ -31,33 +35,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Select strategy
-        id: sel
-        run: echo "strategy=${{ inputs.strategy }}" >> $GITHUB_OUTPUT
-
-      - name: Canary deploy
-        if: steps.sel.outputs.strategy == 'canary'
-        run: |
-          kubectl apply -f apps/${{ inputs.service }}/canary/${{ inputs.service }}-canary.yaml
-
-      - name: Blue/Green update image and switch
-        if: steps.sel.outputs.strategy == 'bluegreen'
-        run: |
-          FILE=apps/${{ inputs.service }}/kustomize/base/deployment-green.yaml
-          sed -i "s#image: .*#image: ${IMAGE_PREFIX}-${{ inputs.service }}:${{ inputs.version }}#" "$FILE"
-          git config user.name "ci"
-          git config user.email "ci@users.noreply.github.com"
-          git commit -am "deploy(${ { inputs.service } }): green ${{ inputs.version }}" || true
-          git push || true
-          echo "ArgoCD sync step intentionally omitted; wire up if needed."
-
-      - name: Direct (GitOps bump)
-        if: steps.sel.outputs.strategy == 'direct'
-        run: |
-          yq -i '.values.services.${{ inputs.service }}.image = "'"${IMAGE_PREFIX}-${{ inputs.service }}:${{ inputs.version }}"'"' infra/helm/gnew-platform/values.${{ inputs.env }}.yaml
-          git config user.name "ci"
-          git config user.email "ci@users.noreply.github.com"
-          git commit -am "deploy(${ { inputs.service } }): direct ${{ inputs.version }}" || true
-          git push || true
+      - run: |
+          case "${{ inputs.strategy }}" in
+            canary)
+              kubectl apply -f apps/${{ inputs.service }}/canary/${{ inputs.service }}-canary.yaml
+              ;;
+            bluegreen)
+              FILE="apps/${{ inputs.service }}/kustomize/base/deployment-green.yaml"
+              sed -i "s#image: .*#image: ${{ env.IMAGE_PREFIX }}-${{ inputs.service }}:${{ inputs.version }}#" "$FILE"
+              git config user.name "ci"
+              git config user.email "ci@users.noreply.github.com"
+              git commit -am "deploy(${ { inputs.service } }): green ${{ inputs.version }}" || true
+              git push || true
+              echo "ArgoCD sync step intentionally omitted; wire up if needed."
+              ;;
+            direct)
+              IMAGE="${{ env.IMAGE_PREFIX }}-${{ inputs.service }}:${{ inputs.version }}"
+              yq -i ".values.services.${{ inputs.service }}.image = \"$IMAGE\"" infra/helm/gnew-platform/values.${{ inputs.env }}.yaml
+              git config user.name "ci"
+              git config user.email "ci@users.noreply.github.com"
+              git commit -am "deploy(${ { inputs.service } }): direct ${{ inputs.version }}" || true
+              git push || true
+              ;;
+            *)
+              echo "Unknown strategy: ${{ inputs.strategy }}"
+              exit 1
+              ;;
+          esac
 


### PR DESCRIPTION
## Summary
- rewrite `workflow_dispatch` inputs without inline arrays
- consolidate deploy strategies into single case-based job

## Testing
- `python - <<'PY'\nimport yaml,sys\nwith open('.github/workflows/deploy-strategy.yml') as f:\n  yaml.safe_load(f)\nprint('YAML OK')\nPY`
- `pnpm test` *(fails: apps/audit-logger test: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac655a2f2083268ec4687dd9d41624