### PR TITLE
chore(web): add Next types to tsconfig

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["node", "react", "react-dom"],
-  "strict": true,
-  "lib": ["ES2023", "DOM"]
+    "types": ["node", "react", "react-dom", "next"],
+    "strict": true,
+    "lib": ["ES2023", "DOM"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- include Next in Web tsconfig types and ensure compiler options are properly nested

## Testing
- `pnpm -w add -D @types/react-dom` *(fails: GET https://registry.npmjs.org/@types%2Freact-dom: Forbidden - 403)*
- `pnpm -w add next-auth` *(fails: GET https://registry.npmjs.org/next-auth: Forbidden - 403)*
- `pnpm -w build` *(fails: Cannot find module 'prism-react-renderer/themes/github')*

------
https://chatgpt.com/codex/tasks/task_e_68ac699680308326978b15d4c49acb80