### PR TITLE
Adjust test configs for audit and billing services

### DIFF
--- a/apps/audit-finance/jest.config.cjs
+++ b/apps/audit-finance/jest.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/apps/audit-finance/package.json
+++ b/apps/audit-finance/package.json
@@ -15,7 +15,8 @@
     "typescript": "^5.4.5",
     "jest": "^29.7.0",
     "@types/jest": "^29.5.12",
-    "@types/express": "^4.17.21"
+    "@types/express": "^4.17.21",
+    "ts-jest": "^29.1.1"
   }
 }
 

--- a/apps/audit-logger/package.json
+++ b/apps/audit-logger/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/apps/billing-aa-service/jest.config.cjs
+++ b/apps/billing-aa-service/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/dist/']
+};


### PR DESCRIPTION
## Summary
- prevent audit logger from failing when no tests present
- enable TypeScript tests for audit-finance
- configure billing-aa-service tests and ignore compiled output

## Testing
- `pnpm test` *(fails: node-mocks-http module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68add6bf69888326a374990b04db3a88