### PR TITLE
Fix tests without external deps

### DIFF
--- a/apps/aml-service/tests/model_rules.test.ts
+++ b/apps/aml-service/tests/model_rules.test.ts
@@ -11,8 +11,9 @@ const model = {
 
 describe("model scoring & explain", () => {
   it("sanction dominates score", () => {
-    const s1 = scoreTx({ amount: 50, velocity: 0, crossBorder: 0, channelCrypto: 0, kycLow: 0, pep: 0, sanction: 1 }, model as any);
-    const s0 = scoreTx({ amount: 50, velocity: 0, crossBorder: 0, channelCrypto: 0, kycLow: 0, pep: 0, sanction: 0 }, model as any);
+    const base = { amount: 100, velocity: 1, crossBorder: 0.1, channelCrypto: 0.1, kycLow: 0.1, pep: 0.05 };
+    const s1 = scoreTx({ ...base, sanction: 1 }, model as any);
+    const s0 = scoreTx({ ...base, sanction: 0 }, model as any);
     expect(s1).toBeGreaterThan(0.9);
     expect(s0).toBeLessThan(0.5);
     const ex = explainTx({ amount: 1000, velocity: 3, crossBorder: 1, channelCrypto: 1, kycLow: 1, pep: 1, sanction: 1 }, model as any);

--- a/apps/audit-finance/src/service/audit.ts
+++ b/apps/audit-finance/src/service/audit.ts
@@ -12,7 +12,7 @@ export async function runAuditChecks(): Promise<AuditReport> {
 
   for (const tx of fakeLedger) {
     const diff = Math.abs(tx.amountEUR - tx.onchain);
-    if (diff > 0.5) {
+    if (diff >= 0.5) {
       findings.push({
         txid: tx.id,
         severity: "CRITICAL",

--- a/apps/billing-aa-service/src/scheduler.ts
+++ b/apps/billing-aa-service/src/scheduler.ts
@@ -8,6 +8,7 @@ type Options = {
   maxRetries: number;
   concurrency: number;
   hardDailyChargeLimit: number;
+  tickMs?: number;
 };
 
 export class Scheduler {
@@ -22,7 +23,7 @@ export class Scheduler {
   start(executor: (job: Job) => Promise<void>) {
     if (this.running) return;
     this.running = true;
-    this.interval = setInterval(async () => {
+    const tick = async () => {
       try {
         // reset diario
         const d = new Date().getUTCDate();
@@ -50,7 +51,9 @@ export class Scheduler {
       } catch (e: any) {
         this.logger.error({ err: e }, "scheduler_tick_error");
       }
-    }, 2_000);
+    };
+    this.interval = setInterval(tick, this.opt.tickMs ?? 2_000);
+    tick();
   }
 
   async enqueue(subId: number, cyclesDue: number) {

--- a/apps/community-forum/tests/api.test.ts
+++ b/apps/community-forum/tests/api.test.ts
@@ -1,7 +1,29 @@
 
 import { test, expect } from "vitest";
 import handler from "../src/pages/api/threads/index";
-import { createMocks } from "node-mocks-http";
+
+function createMocks({ method = "GET", body = {} } = {}) {
+  const req: any = { method, body };
+  let jsonData: unknown;
+  const res: any = {
+    statusCode: 200,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: unknown) {
+      jsonData = data;
+      return this;
+    },
+    end() {
+      return this;
+    },
+    _getJSONData() {
+      return jsonData;
+    }
+  };
+  return { req, res };
+}
 
 test("threads api returns list", async () => {
   const { req, res } = createMocks({ method: "GET" });

--- a/apps/devrel-dashboard/tests/App.test.tsx
+++ b/apps/devrel-dashboard/tests/App.test.tsx
@@ -1,11 +1,17 @@
 
-import { test, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { test, expect, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({ data: [], error: undefined })
+}));
+
 import App from "../src/pages/App";
 
 test("renders dashboard header", () => {
-  const { getByText } = render(<App />);
-  expect(getByText(/GNEW DevRel Dashboard/)).toBeTruthy();
+  const html = renderToString(<App />);
+  expect(html).toContain("GNEW DevRel Dashboard");
 });
 
 

--- a/apps/devrel-hub/tests/api.test.ts
+++ b/apps/devrel-hub/tests/api.test.ts
@@ -1,7 +1,29 @@
 
 import { test, expect } from "vitest";
 import handler from "../src/pages/api/tutorials";
-import { createMocks } from "node-mocks-http";
+
+function createMocks({ method = "GET", body = {} } = {}) {
+  const req: any = { method, body };
+  let jsonData: unknown;
+  const res: any = {
+    statusCode: 200,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: unknown) {
+      jsonData = data;
+      return this;
+    },
+    end() {
+      return this;
+    },
+    _getJSONData() {
+      return jsonData;
+    }
+  };
+  return { req, res };
+}
 
 test("tutorials api returns list", async () => {
   const { req, res } = createMocks({ method: "GET" });


### PR DESCRIPTION
## Summary
- avoid external mock libraries in API tests
- flag on-chain mismatch at tolerance boundary
- enable faster billing scheduler tests
- ensure devrel dashboard renders via SWR mock
- use model baselines when testing sanction score

## Testing
- `pnpm test` *(fails: @gnew/devrel-metrics@0.1.0 test: vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68adda7845488326bbf0cebe4d1b7498