### PR TITLE
chore: type governor simulation script

### DIFF
--- a/services/governance/scripts/simulate-fork.ts
+++ b/services/governance/scripts/simulate-fork.ts
@@ -1,12 +1,27 @@
 import { ethers } from "hardhat";
+import type { EventLog } from "ethers";
+import { GnewGovernor, GnewGovToken } from "../../../packages/contracts/types";
+
+type ProposalId = bigint;
+enum VoteType {
+  Against = 0,
+  For = 1,
+  Abstain = 2,
+}
 /**
  * Simula en red fork: propuesta -> votación -> cola -> ejecución.
  * Control: ejecución sin fallos y cómputo de abstenciones.
  */
 async function main() {
   const [proposer, voterA, voterB] = await ethers.getSigners();
-  const governor = await ethers.getContractAt("GNEWGovernor", process.env.GOVERNOR!);
-  const token = await ethers.getContractAt("GNEWGovernanceToken", process.env.TOKEN!);
+  const governor = (await ethers.getContractAt(
+    "GnewGovernor",
+    process.env.GOVERNOR!
+  )) as unknown as GnewGovernor;
+  const token = (await ethers.getContractAt(
+    "GnewGovToken",
+    process.env.TOKEN!
+  )) as unknown as GnewGovToken;
 
   // Delegar poder de voto
   await (await token.connect(voterA).delegate(voterA.address)).wait();
@@ -17,19 +32,26 @@ async function main() {
   const newDelay = 3 * 24 * 60 * 60;
   const calldata = timelock.interface.encodeFunctionData("updateDelay", [newDelay]);
 
-  const proposeTx = await governor.connect(proposer).propose(
-    [timelock.target as string],
-    [0],
-    [calldata],
-    "Proposal: Update timelock delay to 3 days"
-  );
+  const proposeTx = await governor
+    .connect(proposer)
+    .propose(
+      [timelock.target as string],
+      [0],
+      [calldata],
+      "Proposal: Update timelock delay to 3 days"
+    );
   const rc = await proposeTx.wait();
-  const proposalId = (rc!.logs.find((l) => (l as any).args?.proposalId) as any)?.args?.proposalId;
+  const log = rc?.logs[0] as EventLog;
+  const proposalId = (log.args as unknown as { proposalId: ProposalId }).proposalId;
 
   // Avanza a la votación y vota con ABSTAIN incluido (control: abstención calculada)
   await ethers.provider.send("hardhat_mine", ["0x1000"]); // ~votingDelay
-  await (await governor.connect(voterA).castVote(proposalId, 1)).wait(); // For
-  await (await governor.connect(voterB).castVote(proposalId, 2)).wait(); // Abstain
+  await (
+    await governor.connect(voterA).castVote(proposalId, VoteType.For)
+  ).wait();
+  await (
+    await governor.connect(voterB).castVote(proposalId, VoteType.Abstain)
+  ).wait();
 
   await ethers.provider.send("hardhat_mine", ["0x10000"]); // ~votingPeriod
 


### PR DESCRIPTION
## Summary
- use TypeChain types for Governor and token in simulate-fork script
- type proposal and voting enums to remove `any`

## Testing
- `pnpm --filter @gnew/governance-service build` *(fails: No projects matched the filters)*
- `pnpm --filter governance build`
- `npx eslint services/governance/scripts/simulate-fork.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf3b8971c8326a0fb6f8d8ad53f01