### PR TITLE
refactor: streamline risk scoring helpers

### DIFF
--- a/apps/risk-score/src/service/score.ts
+++ b/apps/risk-score/src/service/score.ts
@@ -5,6 +5,12 @@ type KYC = { country: string; pep: boolean; sanctionsHit: boolean };
 type Behavior = { txVolume: number; disputes: number; chargebacks: number };
 type Liquidity = { assets: number; liabilities: number };
 
+function computeBucket(score: number): "LOW" | "MEDIUM" | "HIGH" {
+  if (score >= 80) return "LOW";
+  if (score >= 50) return "MEDIUM";
+  return "HIGH";
+}
+
 export function scoreCounterparty(input: { kyc: KYC; behavior: Behavior; liquidity: Liquidity }) {
   const { kyc, behavior, liquidity } = input;
 
@@ -29,7 +35,7 @@ export function scoreCounterparty(input: { kyc: KYC; behavior: Behavior; liquidi
 
   return {
     score,
-    bucket: score >= 80 ? "LOW" : score >= 50 ? "MEDIUM" : "HIGH",
+    bucket: computeBucket(score),
     explain: [
       `PEP=${kyc.pep}`,
       `Sanctions=${kyc.sanctionsHit}`,


### PR DESCRIPTION
## Summary
- extract pure helpers to simplify AML score and alert logic
- remove nested ternaries in risk-score service

## Testing
- `pnpm --filter @gnew/risk-score test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `pnpm --filter @gnew/aml-service test` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3e0a8408326beb5764327aff83b