### PR TITLE
feat: add env validation for recon service

### DIFF
--- a/apps/recon-service/.env.example
+++ b/apps/recon-service/.env.example
@@ -1,22 +1,15 @@
-
+# Environment configuration for recon-service
+DATABASE_URL=postgres://USER:PASSWORD@localhost:5432/gnew_recon
+PGUSER=USER
+PGPASSWORD=PASSWORD
 PORT=8096
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/gnew_recon
-LOG_LEVEL=info
-
-# JWT (opcional)
 JWT_AUDIENCE=gnew
 JWT_ISSUER=https://sso.example.com/
-JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
-
-# Alertas
+JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
+RECON_TOLERANCE=0.01
+RECON_DATE_WINDOW_DAYS=3
 ALERT_DIFF_THRESHOLD=0.05
-
-
-Notas mínimas:
-
-Migrar y levantar: pnpm --filter @gnew/recon-service build && pnpm --filter @gnew/recon-service start.
-
-Endpoints clave: /upload/provider, /upload/ledger, /reconcile/run, /reconcile/last/:provider, /healthz.
-
-Siguiente a ejecutar en la próxima interacción: N327 (Motor fiscal EU/US/LatAm).
-
+LOG_LEVEL=info
+# Optional flags
+PG_MEM=0
+DISABLE_AUTH=0

--- a/apps/recon-service/README.md
+++ b/apps/recon-service/README.md
@@ -1,0 +1,14 @@
+# Recon Service
+
+Servicio de conciliación multi-proveedor.
+
+## Configuración de entorno
+
+Copiar `.env.example` a `.env` y completar las variables:
+
+- `DATABASE_URL`: URL de conexión a Postgres.
+- `PGUSER`, `PGPASSWORD`: credenciales para la base de datos.
+- `PORT`: puerto de escucha.
+- Variables JWT y tolerancias para reconciliación.
+
+Las variables se validan mediante [Zod](https://github.com/colinhacks/zod). La aplicación no arrancará si falta alguna obligatoria.

--- a/apps/recon-service/src/config/env.ts
+++ b/apps/recon-service/src/config/env.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+const Env = z.object({
+  DATABASE_URL: z.union([z.string().url(), z.literal("pgmem"), z.literal("mem")]),
+  PGUSER: z.string().optional(),
+  PGPASSWORD: z.string().optional(),
+  PORT: z.coerce.number().default(8096),
+  JWT_AUDIENCE: z.string().default("gnew"),
+  JWT_ISSUER: z.string().default("https://sso.example.com/"),
+  JWT_PUBLIC_KEY: z.string().transform((s) => s.replace(/\\n/g, "\n")).default(""),
+  RECON_TOLERANCE: z.coerce.number().default(0.01),
+  RECON_DATE_WINDOW_DAYS: z.coerce.number().default(3),
+  ALERT_DIFF_THRESHOLD: z.coerce.number().default(0.05),
+  LOG_LEVEL: z.string().default("info"),
+  PG_MEM: z.string().optional(),
+  DISABLE_AUTH: z.string().optional(),
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+});
+
+export const env = Env.parse(process.env);

--- a/apps/recon-service/src/server.ts
+++ b/apps/recon-service/src/server.ts
@@ -1,14 +1,15 @@
 import { ensureMigrations } from "./db/migrate";
 import createApp from "./app";
+import { env } from "./config/env";
 
-const PORT = Number(process.env.PORT ?? 8096);
+const PORT = env.PORT;
 
 async function main() {
   const { app, pool } = await createApp();
   // Ensure DB schema on boot (best-effort)
   ensureMigrations(pool).catch((err) => console.warn("migrations_on_boot_failed", err));
   app.listen(PORT, () => {
-    const mem = process.env.PG_MEM === "1" || process.env.DATABASE_URL === "pgmem" || process.env.DATABASE_URL === "mem";
+    const mem = env.PG_MEM === "1" || env.DATABASE_URL === "pgmem" || env.DATABASE_URL === "mem";
     console.log(JSON.stringify({ level: 30, port: PORT, mem, msg: "recon-service_started" }));
   });
 }

--- a/apps/recon-service/tests/app.test.ts
+++ b/apps/recon-service/tests/app.test.ts
@@ -4,8 +4,13 @@
  * Usamos pg-mem para DB en tests (sin extensiones).
  */
 import request from "supertest";
-import app from "../src/app";
 import { newDb } from "pg-mem";
+
+let app: any;
+beforeAll(async () => {
+  process.env.DATABASE_URL = "pgmem";
+  app = (await import("../src/app")).default;
+});
 
 // Patch pg with pg-mem and preload migration
 jest.mock("pg", () => {


### PR DESCRIPTION
## Summary
- validate recon-service environment with Zod
- replace hardcoded credentials with env variables
- document required variables with example file

## Testing
- `pnpm --filter @gnew/recon-service test` *(fails: jest not found)*
- `pnpm --filter @gnew/recon-service build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3cd92ec83269da45f12624e5304