### PR TITLE
chore: enforce readonly props

### DIFF
--- a/apps/devrel-dashboard/src/ui/QuickstartChart.tsx
+++ b/apps/devrel-dashboard/src/ui/QuickstartChart.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { ResponsiveContainer, BarChart, XAxis, YAxis, Tooltip, Legend, Bar } from "recharts";
 
-type Props = { metrics: { lang: string; runs: number; avgSeconds: number }[] };
+type Props = Readonly<{ metrics: { lang: string; runs: number; avgSeconds: number }[] }>;
 
 export function QuickstartChart({ metrics }: Props) {
   return (

--- a/apps/governance-ui/src/components/DelegationCard.tsx
+++ b/apps/governance-ui/src/components/DelegationCard.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react"; 
 import { BrowserProvider, Contract, Eip1193Provider, ethers, type InterfaceAbi } from "ethers"; 
 import DelegationAbi from "../abis/delegation"; 
-type Props = { 
-contractAddress: string; 
-scopeLabel?: string; // p.ej. "TOKEN_VOTES" | "REPUTATION_VOTES" 
-}; 
+type Props = Readonly<{
+contractAddress: string;
+scopeLabel?: string; // p.ej. "TOKEN_VOTES" | "REPUTATION_VOTES"
+}>;
 function toBytes32(label: string) { 
 return ethers.id(label); 
 } 

--- a/apps/governance-ui/src/components/QueueExecutePanel.tsx
+++ b/apps/governance-ui/src/components/QueueExecutePanel.tsx
@@ -3,8 +3,8 @@ import { Contract, ethers } from "ethers";
 import { getSigner } from "../eth"; 
 import { ABIS } from "../abi"; 
  
-export default function QueueExecutePanel({ proposalId, description }: 
-{ proposalId: string; description: string }) { 
+export default function QueueExecutePanel({ proposalId, description }:
+Readonly<{ proposalId: string; description: string }>) {
   const [tx1, setTx1] = useState(""); const [tx2, setTx2] = 
 useState(""); 
  

--- a/apps/governance-ui/src/components/VotePanel.tsx
+++ b/apps/governance-ui/src/components/VotePanel.tsx
@@ -3,8 +3,8 @@ import { Contract } from "ethers";
 import { getSigner } from "../eth"; 
 import { ABIS } from "../abi"; 
  
-export default function VotePanel({ proposalId }: { proposalId: string 
-}) { 
+export default function VotePanel({ proposalId }: Readonly<{ proposalId: string
+}>) {
   const [state, setState] = useState<number>(0); 
   const [reason, setReason] = useState(""); 
   const [q, setQ] = useState<{ for: bigint; against: bigint; abstain: 

--- a/apps/web/components/AISuggestions.tsx
+++ b/apps/web/components/AISuggestions.tsx
@@ -8,11 +8,11 @@ export default function AISuggestions({
   conversationId,
   messages,
   lang = "es",
-}: {
+}: Readonly<{
   conversationId?: string;
   messages: Msg[];
   lang?: "es" | "en";
-}) {
+}>) {
   const [loading, setLoading] = useState(false);
   const [error, setErr] = useState<string | null>(null);
   const [data, setData] = useState<Awaited<ReturnType<typeof callSummarize>> | null>(null);

--- a/apps/web/components/VariantsPanel.tsx
+++ b/apps/web/components/VariantsPanel.tsx
@@ -11,8 +11,8 @@ LineChart, Line, CartesianGrid,
 type VariantKey = "one_person_one_vote" | "token_weighted" | 
 "quadratic_voting"; 
  
-export default function VariantsPanel({ demo = false }: { demo?: 
-boolean }) { 
+export default function VariantsPanel({ demo = false }: Readonly<{ demo?:
+boolean }>) {
   const [loading, setLoading] = useState(false); 
   const [err, setErr] = useState<string | null>(null); 
   const [data, setData] = useState<any | null>(null); 

--- a/apps/web/components/consent/ChannelFlowModal.tsx
+++ b/apps/web/components/consent/ChannelFlowModal.tsx
@@ -9,7 +9,7 @@ type ConsentState = {
   onchain: { marketing: boolean };
 };
 
-export default function ChannelFlowModal({ subjectId, open, onClose }:{ subjectId:string; open:boolean; onClose:()=>void }) { 
+export default function ChannelFlowModal({ subjectId, open, onClose }: Readonly<{ subjectId:string; open:boolean; onClose:()=>void }>) {
   const [mv, setMv] = useState<string>("v1"); 
   const [state, setState] = useState<ConsentState>({
     email: { marketing: false },
@@ -105,17 +105,16 @@ auditados y puedes revocar en cualquier momento.</p>
   ); 
 } 
  
-function Section({ title, children }:{ title:string; 
-children:React.ReactNode }) { 
-  return <div className="space-y-2"><h3 
-className="font-medium">{title}</h3><div 
-className="space-y-2">{children}</div></div>; 
-} 
-function Toggle({ label, checked, onChange }:{ label:string; 
-checked:boolean; onChange:(v:boolean)=>void }) { 
-  return <label className="flex items-center justify-between p-3 
-border rounded-lg"><span className="text-sm">{label}</span><input 
-type="checkbox" checked={checked} 
-onChange={e=>onChange(e.target.checked)}/></label>; 
-} 
+function Section({ title, children }: Readonly<{ title:string;
+children:React.ReactNode }>) {
+  return <div className="space-y-2"><h3
+className="font-medium">{title}</h3><div
+className="space-y-2">{children}</div></div>;
+}
+function Toggle({ label, checked, onChange }: Readonly<{ label:string;
+checked:boolean; onChange:(v:boolean)=>void }>) {
+  return <label className="flex items-center justify-between p-3
+border rounded-lg"><span className="text-sm">{label}</span><input type="checkbox" checked={checked}
+onChange={e=>onChange(e.target.checked)}/></label>;
+}
  

--- a/apps/web/components/consent/ConsentBanner.tsx
+++ b/apps/web/components/consent/ConsentBanner.tsx
@@ -1,8 +1,8 @@
 "use client"; 
 import React, { useEffect, useState } from "react"; 
 type Catalog = { uses: any[]; dataCategories: any[]; channels: any[]; matrixVersion: string };
-export default function ConsentBanner({ subjectId }: { subjectId: 
-string }) { 
+export default function ConsentBanner({ subjectId }: Readonly<{ subjectId:
+string }>) {
 const [visible, setVisible] = useState(false); 
 const [catalog, setCatalog] = useState<Catalog | null>(null); 
 const [choices, setChoices] = useState<any>({
@@ -89,8 +89,8 @@ href="/privacy">Política y configuración avanzada</a>
   ); 
 } 
  
-function Card({ title, checked, onChange }:{ title:string; 
-checked:boolean; onChange:(v:boolean)=>void }) { 
+function Card({ title, checked, onChange }: Readonly<{ title:string;
+checked:boolean; onChange:(v:boolean)=>void }>) {
   return ( 
     <label className="p-3 border rounded-xl flex items-center 
 justify-between"> 

--- a/apps/web/components/consent/ConsentCenter.tsx
+++ b/apps/web/components/consent/ConsentCenter.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react"; 
 import { useConsentStore } from "./store"; 
  
-export default function ConsentCenter({ subjectId }: { subjectId: 
-string }) { 
+export default function ConsentCenter({ subjectId }: Readonly<{ subjectId:
+string }>) {
   const { loadCatalog, loadState, catalog, state, toggle, save } = 
 useConsentStore(); 
  

--- a/gnew/apps/web/components/recovery/RecoveryFlow.tsx
+++ b/gnew/apps/web/components/recovery/RecoveryFlow.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react"; 
 type Guardian = { address: string; did?: string }; 
-type Props = { 
-guardians: Guardian[]; threshold: number; contract: string; chainId: 
-number; 
-timelockSec: number; expirySec: number; 
-}; 
-export default function RecoveryFlow({ guardians, threshold, contract, 
-chainId, timelockSec, expirySec }: Props) { 
+type Props = Readonly<{
+guardians: Guardian[]; threshold: number; contract: string; chainId:
+number;
+timelockSec: number; expirySec: number;
+}>;
+export default function RecoveryFlow({ guardians, threshold, contract,
+chainId, timelockSec, expirySec }: Props) {
   const [proposed, setProposed] = useState(""); 
   const [sigs, setSigs] = useState<{signer:string; sig:string}[]>([]); 
   const [nonce, setNonce] = useState<number>(0); 

--- a/gnew/apps/web/components/reputation/AppealForm.tsx
+++ b/gnew/apps/web/components/reputation/AppealForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"; 
  
-export default function AppealForm({ address, epoch, version }:{ 
-address:string; epoch:number; version:number }) { 
+export default function AppealForm({ address, epoch, version }: Readonly<{
+address:string; epoch:number; version:number }>) {
   const [category, setCategory] = useState("dato_incorrecto"); 
   const [desc, setDesc] = useState(""); 
   const [link, setLink] = useState(""); 

--- a/gnew/apps/web/components/reputation/TipsBox.tsx
+++ b/gnew/apps/web/components/reputation/TipsBox.tsx
@@ -1,7 +1,7 @@
 import React from "react"; 
 import { improvementTips } from "@gnew/sdk/reputation_panel"; 
  
-export default function TipsBox({ items }:{ items:any[] }) { 
+export default function TipsBox({ items }: Readonly<{ items:any[] }>) {
   const tips = improvementTips(items); 
   if (!tips.length) return null; 
   return ( 

--- a/gnew/apps/web/kpi-dashboard/components/Filters.tsx
+++ b/gnew/apps/web/kpi-dashboard/components/Filters.tsx
@@ -1,7 +1,7 @@
-type Props = {
+type Props = Readonly<{
   chain: string; network: string; token: string; range: string;
   onChange: (p: {chain:string; network:string; token:string; range:string}) => void;
-};
+}>;
 export function Filters({ chain, network, token, range, onChange }: Props) {
   return (
     <>

--- a/packages/ui/src/policy-editor/PolicyEditor.tsx
+++ b/packages/ui/src/policy-editor/PolicyEditor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 
-type Props = {
+type Props = Readonly<{
   backend?: string; // http://localhost:8030
   activeVersion?: number;
-};
+}>;
 
 export default function PolicyEditor({ backend = "http://localhost:8030", activeVersion }: Props) {
   const [model, setModel] = useState<string>("");

--- a/packages/ui/src/survey/SurveyBuilder.tsx
+++ b/packages/ui/src/survey/SurveyBuilder.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import type { Question } from "./types";
 
-type Props = { endpoint?: string };
+type Props = Readonly<{ endpoint?: string }>;
 export const SurveyBuilder: React.FC<Props> = ({ endpoint = "/feedback" }) => {
   const [name, setName] = useState("");
   const [trigger, setTrigger] = useState("post-votacion");

--- a/packages/ui/src/survey/SurveyModal.tsx
+++ b/packages/ui/src/survey/SurveyModal.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
 import type { Survey, Question } from "./types";
 
-type Props = {
+type Props = Readonly<{
   survey: Survey;
   userId: string;
   event: string;
   onClose: () => void;
   endpoint?: string; // e.g. /feedback
-};
+}>;
 
 export const SurveyModal: React.FC<Props> = ({ survey, userId, event, onClose, endpoint = "/feedback" }) => {
   const [answers, setAnswers] = useState<Record<string, number | string>>({});


### PR DESCRIPTION
## Summary
- make component props immutable with `Readonly`

## Testing
- `pnpm lint` *(fails: Cannot read config file: gnew/devrel/quickstarts/node-basic/package.json)*
- `pnpm typecheck` *(fails: TS5083 Cannot read file '/workspace/GNEW3/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_68adf48fc9188326a6ad606ceaa1395c