### PR TITLE
chore: improve ts consistency

### DIFF
--- a/apps/data/catalog-bridge/src/routes/catalog.ts
+++ b/apps/data/catalog-bridge/src/routes/catalog.ts
@@ -10,8 +10,8 @@ catalog.get("/catalog/databases", (_req, res) => {
 });
 
 catalog.get("/catalog/tables", (req, res) => {
-  const dbName = String(req.query.db ?? "");
-  const q = String((req.query.q ?? "") as string).trim();
+  const dbName = typeof req.query.db === "string" ? req.query.db : "";
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
   if (!dbName) return res.status(400).json({ ok: false, error: "db_required" });
   const rows = q
     ? db.prepare("SELECT name, description, location, format FROM tables WHERE dbName=? AND (name LIKE ? OR description LIKE ?) ORDER BY name ASC")
@@ -29,8 +29,8 @@ catalog.get("/catalog/tables/:db/:table", (req, res) => {
 });
 
 catalog.get("/catalog/columns", (req, res) => {
-  const dbName = String(req.query.db ?? "");
-  const table = String(req.query.table ?? "");
+  const dbName = typeof req.query.db === "string" ? req.query.db : "";
+  const table = typeof req.query.table === "string" ? req.query.table : "";
   if (!dbName || !table) return res.status(400).json({ ok: false, error: "db_table_required" });
   const rows = db.prepare("SELECT name, type, comment, position FROM columns WHERE dbName=? AND tableName=? ORDER BY position ASC")
     .all(dbName, table);
@@ -38,8 +38,8 @@ catalog.get("/catalog/columns", (req, res) => {
 });
 
 catalog.get("/catalog/partitions", (req, res) => {
-  const dbName = String(req.query.db ?? "");
-  const table = String(req.query.table ?? "");
+  const dbName = typeof req.query.db === "string" ? req.query.db : "";
+  const table = typeof req.query.table === "string" ? req.query.table : "";
   const limit = Math.min(5000, Math.max(1, Number(req.query.limit ?? 200)));
   if (!dbName || !table) return res.status(400).json({ ok: false, error: "db_table_required" });
   const rows = db.prepare("SELECT spec, location FROM partitions WHERE dbName=? AND tableName=? ORDER BY spec ASC LIMIT ?")
@@ -49,7 +49,7 @@ catalog.get("/catalog/partitions", (req, res) => {
 });
 
 catalog.get("/search", (req, res) => {
-  const q = String(req.query.q ?? "").trim();
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
   if (!q) return res.status(400).json({ ok: false, error: "q_required" });
   const rows = db.prepare(`
     SELECT kind, dbName, tableName, name, description, location, columns

--- a/apps/data/catalog-bridge/src/routes/sync.ts
+++ b/apps/data/catalog-bridge/src/routes/sync.ts
@@ -1,27 +1,32 @@
 
-import { Router } from "express";
+import { Router, NextFunction } from "express";
+import pino from "pino";
 import { syncFromGlue, importFromJson } from "../sync.js";
 import { z } from "zod";
 
+const logger = pino();
+
 export const syncRoutes = Router();
 
-syncRoutes.post("/sync/glue", async (_req, res) => {
+syncRoutes.post("/sync/glue", async (_req, res, next: NextFunction) => {
   try {
     const out = await syncFromGlue();
     res.json({ ok: true, ...out });
   } catch (e: any) {
-    res.status(500).json({ ok: false, error: e?.message ?? String(e) });
+    logger.error(e);
+    next(e);
   }
 });
 
-syncRoutes.post("/sync/import", (req, res) => {
+syncRoutes.post("/sync/import", (req, res, next: NextFunction) => {
   const Body = z.any(); // validación la hace el importador de forma laxa
   try {
     Body.parse(req.body ?? {});
     const out = importFromJson(req.body);
     res.json({ ok: true, ...out });
   } catch (e: any) {
-    res.status(400).json({ ok: false, error: e?.message ?? String(e) });
+    logger.error(e);
+    next(e);
   }
 });
 

--- a/apps/data/catalog-bridge/src/sync.ts
+++ b/apps/data/catalog-bridge/src/sync.ts
@@ -1,8 +1,11 @@
 
 import crypto from "node:crypto";
+import pino from "pino";
 import { db } from "./db.js";
 import { cfg } from "./config.js";
 import { makeGlue, listDatabases, listTables, listPartitions } from "./glue.js";
+
+const logger = pino();
 
 function id() { return crypto.randomUUID(); }
 
@@ -64,6 +67,7 @@ export async function syncFromGlue(): Promise<{ runId: string; dbs: number; tabl
     finishRun(runId, true, { dbs, tables, cols, parts });
     return { runId, dbs, tables, cols, parts };
   } catch (e: any) {
+    logger.error(e);
     finishRun(runId, false, { error: e?.message ?? String(e) });
     throw e;
   }
@@ -123,6 +127,7 @@ export function importFromJson(payload: any): { runId: string; dbs: number; tabl
     finishRun(runId, true, { dbs, tables, cols, parts });
     return { runId, dbs, tables, cols, parts };
   } catch (e: any) {
+    logger.error(e);
     finishRun(runId, false, { error: e?.message ?? String(e) });
     throw e;
   }

--- a/apps/dsar-svc/src/routes/dsar.ts
+++ b/apps/dsar-svc/src/routes/dsar.ts
@@ -8,13 +8,13 @@ import { computeDueAt } from "../services/sla";
 export const router = Router(); 
  
 // GET list (admin console) 
-router.get("/requests", requireAdmin, async (req, res) => { 
-  const status = req.query.status as string | undefined; 
-  const where = status ? { status } : {}; 
-  const items = await prisma.dSARRequest.findMany({ where, orderBy: { 
-createdAt: "desc" }, take: 100 }); 
-  res.json({ items }); 
-}); 
+router.get("/requests", requireAdmin, async (req, res) => {
+  const status = typeof req.query.status === "string" ? req.query.status : undefined;
+  const where = status ? { status } : {};
+  const items = await prisma.dSARRequest.findMany({ where, orderBy: {
+createdAt: "desc" }, take: 100 });
+  res.json({ items });
+});
  
 // POST create (subject/self-serve portal o soporte) 
 router.post("/requests", requireSubjectAuth, async (req, res) => { 

--- a/services/authz/src/server.ts
+++ b/services/authz/src/server.ts
@@ -76,7 +76,7 @@ app.post("/authz/evaluate", async (req: Request, res: Response) => {
 
   const cacheKey = JSON.stringify([policyVersion, input.sub.role, input.sub.id, input.obj, input.act, input.ctx?.tenant, input.ctx?.projectOwnerId]);
   const cached = cache.get(cacheKey);
-  if (cached && cached.v === policyVersion) {
+  if (cached?.v === policyVersion) {
     const latency = performance.now() - start;
     H.observe(latency);
     C.labels(String(cached.decision)).inc();


### PR DESCRIPTION
## Summary
- normalize query params to safe strings
- log and propagate sync errors
- use optional chaining on cached policy version check

## Testing
- `pnpm exec eslint apps/dsar-svc/src/routes/dsar.ts apps/data/catalog-bridge/src/routes/catalog.ts apps/data/catalog-bridge/src/routes/sync.ts apps/data/catalog-bridge/src/sync.ts services/authz/src/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf4a38f2c83269fa27b52e812c24f