### PR TITLE
chore: enforce immutability and concrete typings

### DIFF
--- a/apps/billing-aa-service/src/bundler.ts
+++ b/apps/billing-aa-service/src/bundler.ts
@@ -4,7 +4,6 @@
  * NOTA: Firmas de userOp y de paymasterAndData deben resolverse con vuestro stack AA.
  * Este cliente asume que ya recibimos el userOp firmado del sender y del paymaster.
  */
-import { ethers } from "ethers";
 
 type AACharge = {
   sender: string;      // smart account del collector autorizado
@@ -14,7 +13,7 @@ type AACharge = {
 };
 
 export class BundlerClient {
-  constructor(private bundlerRpc: string, private entryPoint: string) {}
+  constructor(private readonly bundlerRpc: string, private readonly entryPoint: string) {}
 
   async chargeViaAA(req: AACharge) {
     // Monta una userOp mínima de ejemplo con callData directo al target a través del smart account del sender.

--- a/apps/billing-aa-service/src/scheduler.ts
+++ b/apps/billing-aa-service/src/scheduler.ts
@@ -18,7 +18,7 @@ export class Scheduler {
   private chargedToday = 0;
   private lastResetDay = new Date().getUTCDate();
 
-  constructor(private store: JobsMemStore, private logger: Logger, private opt: Options) {}
+  constructor(private readonly store: JobsMemStore, private readonly logger: Logger, private readonly opt: Options) {}
 
   start(executor: (job: Job) => Promise<void>) {
     if (this.running) return;

--- a/apps/billing-aa-service/src/store.ts
+++ b/apps/billing-aa-service/src/store.ts
@@ -10,9 +10,9 @@ export type Job = {
 };
 
 export class JobsMemStore {
-  private watched = new Set<number>();
-  private q: Job[] = [];
-  private progress = new Set<string>();
+  private readonly watched = new Set<number>();
+  private readonly q: Job[] = [];
+  private readonly progress = new Set<string>();
   private done = 0;
   private failed = 0;
 
@@ -48,14 +48,16 @@ export class JobsMemStore {
     this.done++;
   }
 
-  async retryLater(job: Job, backoffMs: number, _reason: string) {
+  async retryLater(job: Job, backoffMs: number, reason: string) {
+    void reason;
     job.retries = (job.retries ?? 0) + 1;
     job.nextRunAt = Date.now() + backoffMs;
     if (!job.id) job.id = `${job.subId}:${Date.now()}:${Math.random()}`;
     this.q.push(job);
   }
 
-  async giveUp(job: Job, _reason: string) {
+  async giveUp(job: Job, reason: string) {
+    void reason;
     if (job.id) this.progress.delete(job.id);
     this.failed++;
   }

--- a/apps/checkout-sdk/src/index.ts
+++ b/apps/checkout-sdk/src/index.ts
@@ -16,7 +16,7 @@ import { signIntent, verifyWebhook } from "./utils/crypto";
 import type { CheckoutIntent, CheckoutOptions } from "./types";
 
 export class GnewCheckout {
-  private apiBase: string;
+  private readonly apiBase: string;
   constructor(apiBase: string) {
     this.apiBase = apiBase;
   }

--- a/apps/data/lineage-service/src/store.ts
+++ b/apps/data/lineage-service/src/store.ts
@@ -2,9 +2,17 @@
 import { db } from "./db.js";
 import { nanoid } from "nanoid";
 
+interface Dataset {
+  id: string;
+  namespace: string;
+  name: string;
+  key: string;
+  createdAt: number;
+}
+
 export function upsertDataset(ns: string, name: string): { id: string; key: string } {
   const key = `${ns}.${name}`;
-  const row = db.prepare("SELECT id FROM datasets WHERE key=?").get(key) as any;
+  const row = db.prepare("SELECT id FROM datasets WHERE key=?").get(key) as { id?: string } | undefined;
   if (row?.id) return { id: row.id, key };
   const id = nanoid();
   db.prepare("INSERT INTO datasets(id,namespace,name,key,createdAt) VALUES(?,?,?,?,?)")
@@ -16,7 +24,9 @@ export function upsertDataset(ns: string, name: string): { id: string; key: stri
 }
 
 export function bumpVersion(datasetId: string): number {
-  const last = db.prepare("SELECT MAX(version) v FROM dataset_versions WHERE datasetId=?").get(datasetId) as any;
+  const last = db
+    .prepare("SELECT MAX(version) v FROM dataset_versions WHERE datasetId=?")
+    .get(datasetId) as { v?: number } | undefined;
   const next = Number(last?.v ?? 1) + 1;
   db.prepare("INSERT INTO dataset_versions(id,datasetId,version,createdAt) VALUES(?,?,?,?)")
     .run(nanoid(), datasetId, next, Date.now());
@@ -31,8 +41,9 @@ export function setSchema(datasetId: string, version: number, cols: Array<{ name
   }
 }
 
-export function findDatasetByKey(key: string): any | null {
-  return db.prepare("SELECT * FROM datasets WHERE key=?").get(key) as any;
+export function findDatasetByKey(key: string): Dataset | null {
+  const row = db.prepare("SELECT * FROM datasets WHERE key=?").get(key) as Dataset | undefined;
+  return row ?? null;
 }
 
 

--- a/apps/pricing-service/src/engine/engine.ts
+++ b/apps/pricing-service/src/engine/engine.ts
@@ -1,12 +1,12 @@
 
 import { LRU } from "./lru";
 import { qkey } from "../util/hash";
-import { Ruleset, QuoteInput, QuoteResult, Rule, DiscountEffect } from "./types";
+import { QuoteInput, QuoteResult, Rule, DiscountEffect } from "./types";
 import { RulesStore } from "../store/rules";
 
 export class PriceEngine {
-  private cache: LRU<string, QuoteResult>;
-  constructor(private store: RulesStore) {
+  private readonly cache: LRU<string, QuoteResult>;
+  constructor(private readonly store: RulesStore) {
     const size = Number(process.env.CACHE_SIZE ?? 10_000);
     const ttl = Number(process.env.CACHE_TTL_MS ?? 60_000);
     this.cache = new LRU(size, ttl);

--- a/apps/pricing-service/src/engine/lru.ts
+++ b/apps/pricing-service/src/engine/lru.ts
@@ -1,8 +1,8 @@
 
 export class LRU<K, V> {
-  private max: number;
-  private ttlMs: number;
-  private map = new Map<K, { v: V; t: number }>();
+  private readonly max: number;
+  private readonly ttlMs: number;
+  private readonly map = new Map<K, { v: V; t: number }>();
 
   constructor(max = 5000, ttlMs = 60_000) {
     this.max = max;

--- a/apps/pricing-service/src/store/audit.ts
+++ b/apps/pricing-service/src/store/audit.ts
@@ -11,8 +11,8 @@ export type AuditEvent = {
 };
 
 export class AuditStore {
-  private file?: string;
-  private buf: AuditEvent[] = [];
+  private readonly file?: string;
+  private readonly buf: AuditEvent[] = [];
 
   constructor(filePath?: string) {
     if (filePath && filePath.trim().length > 0) {

--- a/apps/search/rag-service/src/embeddings/local.ts
+++ b/apps/search/rag-service/src/embeddings/local.ts
@@ -4,7 +4,7 @@ import { EmbeddingProvider } from "./provider.js";
 
 /** Embeddings locales deterministas, 384-d, estilo hashing bag-of-words */
 export class LocalEmbedding implements EmbeddingProvider {
-  private D = 384;
+  private readonly D = 384;
   dim() { return this.D; }
   async embed(texts: string[]) {
     return texts.map((t) => this.embedOne(t));

--- a/apps/search/rag-service/src/embeddings/openai.ts
+++ b/apps/search/rag-service/src/embeddings/openai.ts
@@ -3,7 +3,7 @@ import { EmbeddingProvider } from "./provider.js";
 import https from "node:https";
 
 export class OpenAIEmbedding implements EmbeddingProvider {
-  constructor(private apiKey: string) {}
+  constructor(private readonly apiKey: string) {}
   dim() { return 1536; }
   async embed(texts: string[]) {
     const body = JSON.stringify({ input: texts, model: "text-embedding-3-small" });

--- a/mnt/data/gnew/packages/storage/src/multiRegionObjectStore.ts
+++ b/mnt/data/gnew/packages/storage/src/multiRegionObjectStore.ts
@@ -14,8 +14,8 @@ interface MultiRegionObjectStoreOptions {
 }
 
 export class MultiRegionObjectStore {
-  private primary: RegionConfig;
-  private replicas: RegionConfig[];
+  private readonly primary: RegionConfig;
+  private readonly replicas: RegionConfig[];
 
   constructor(options: MultiRegionObjectStoreOptions) {
     this.primary = options.primary;

--- a/packages/checkout-sdk/src/fiat.ts
+++ b/packages/checkout-sdk/src/fiat.ts
@@ -3,7 +3,7 @@ import { Http } from "./http.js";
 import type { QuoteReq, Quote, CreateOrderParams, Order } from "./types.js";
 
 export class FiatRampClient {
-  private http: Http;
+  private readonly http: Http;
   constructor(opts: { baseUrl: string; timeoutMs?: number }) {
     this.http = new Http(opts.baseUrl, opts.timeoutMs);
   }

--- a/packages/checkout-sdk/src/http.ts
+++ b/packages/checkout-sdk/src/http.ts
@@ -1,6 +1,6 @@
 
 export class Http {
-  constructor(private baseUrl: string, private timeoutMs = 15000) {}
+  constructor(private readonly baseUrl: string, private readonly timeoutMs = 15000) {}
 
   async get<T>(path: string, params?: Record<string, any>): Promise<T> {
     const url = new URL(path, this.baseUrl);

--- a/packages/checkout-sdk/src/subscriptions.ts
+++ b/packages/checkout-sdk/src/subscriptions.ts
@@ -2,11 +2,11 @@
 import { Http } from "./http.js";
 import type {
   CreatePlanParams, Plan,
-  CreateSubscriptionParams, Subscription
+  CreateSubscriptionParams
 } from "./types.js";
 
 export class SubscriptionsClient {
-  private http: Http;
+  private readonly http: Http;
   constructor(opts: { baseUrl: string; timeoutMs?: number }) {
     this.http = new Http(opts.baseUrl, opts.timeoutMs);
   }

--- a/packages/contracts/typechain-types/hardhat.d.ts
+++ b/packages/contracts/typechain-types/hardhat.d.ts
@@ -41,12 +41,12 @@ declare module "hardhat/types/runtime" {
       signerOrOptions?: ethers.Signer | FactoryOptions
     ): Promise<ethers.ContractFactory>;
     getContractFactory(
-      abi: any[],
+      abi: ethers.InterfaceAbi,
       bytecode: ethers.BytesLike,
       signer?: ethers.Signer
     ): Promise<ethers.ContractFactory>;
     getContractAt(
-      nameOrAbi: string | any[],
+      nameOrAbi: string | ethers.InterfaceAbi,
       address: string | ethers.Addressable,
       signer?: ethers.Signer
     ): Promise<ethers.Contract>;

--- a/packages/sdk/src/clients/antiCollusion.ts
+++ b/packages/sdk/src/clients/antiCollusion.ts
@@ -1,7 +1,7 @@
 export type LabelItem = { kind: "group" | "user"; key: string | number; y: 0 | 1 };
 
 export class AntiCollusionClient {
-  constructor(private baseUrl: string, private token?: string) {}
+  constructor(private readonly baseUrl: string, private readonly token?: string) {}
   private h() {
     return {
       "Content-Type": "application/json",

--- a/packages/sdk/src/clients/reviews.ts
+++ b/packages/sdk/src/clients/reviews.ts
@@ -9,7 +9,7 @@ export type ReviewPayload = {
 };
 
 export class ReviewsClient {
-  constructor(private baseUrl: string, private token?: string) {}
+  constructor(private readonly baseUrl: string, private readonly token?: string) {}
   private h() {
     return {
       "Content-Type": "application/json",

--- a/services/auth/passkeys/passkeyManager.ts
+++ b/services/auth/passkeys/passkeyManager.ts
@@ -23,7 +23,7 @@ export interface AuthenticationOptions {
 }
 
 export class PasskeyManager {
-  private store: Map<string, any> = new Map();
+  private readonly store: Map<string, any> = new Map();
 
   generateRegistrationOptions(userId: string, username: string): RegistrationOptions {
     const challenge = generateChallenge();

--- a/services/data-governance/fieldEncryptor.ts
+++ b/services/data-governance/fieldEncryptor.ts
@@ -15,8 +15,8 @@ interface FieldPolicy {
 const ALGORITHM = "aes-256-gcm";
 
 export class FieldEncryptor {
-  private key: Buffer;
-  private policies: Record<string, FieldPolicy> = {};
+  private readonly key: Buffer;
+  private readonly policies: Record<string, FieldPolicy> = {};
 
   constructor(secret: string) {
     this.key = crypto.createHash("sha256").update(secret).digest();

--- a/services/finops/gasOptimizer.ts
+++ b/services/finops/gasOptimizer.ts
@@ -14,7 +14,7 @@ export interface GasEstimation {
 }
 
 export class GasOptimizer {
-  private provider: ethers.JsonRpcProvider;
+  private readonly provider: ethers.JsonRpcProvider;
 
   constructor(rpcUrl: string) {
     this.provider = new ethers.JsonRpcProvider(rpcUrl);

--- a/services/identity/m9-key-did-manager.ts
+++ b/services/identity/m9-key-did-manager.ts
@@ -25,7 +25,7 @@ class MPCStub {
 }
 
 export class DIDManager {
-  private docs: Map<string, DIDDocument> = new Map();
+  private readonly docs: Map<string, DIDDocument> = new Map();
 
   createDID(): DIDDocument {
     const pubKey = MPCStub.generateKey();

--- a/services/identity/sybil-score.ts
+++ b/services/identity/sybil-score.ts
@@ -15,7 +15,7 @@ interface SybilSignal {
 }
 
 export class SybilScorer {
-  private driver: Driver;
+  private readonly driver: Driver;
 
   constructor(uri: string, user: string, password: string) {
     this.driver = neo4j.driver(uri, neo4j.auth.basic(user, password));

--- a/services/mev-guard/index.ts
+++ b/services/mev-guard/index.ts
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 import FairOrdering from "../../artifacts/contracts/mev/FairOrdering.sol/FairOrdering.json";
 
 export class MevGuardSDK {
-  private contract: ethers.Contract;
+  private readonly contract: ethers.Contract;
 
   constructor(address: string, provider: ethers.JsonRpcProvider, signer?: ethers.Signer) {
     this.contract = new ethers.Contract(address, FairOrdering.abi, signer || provider);

--- a/services/paymaster-sdk/index.ts
+++ b/services/paymaster-sdk/index.ts
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 import DynamicPaymaster from "../../artifacts/contracts/paymasters/DynamicPaymaster.sol/DynamicPaymaster.json";
 
 export class PaymasterSDK {
-  private contract: ethers.Contract;
+  private readonly contract: ethers.Contract;
 
   constructor(address: string, provider: ethers.JsonRpcProvider, signer?: ethers.Signer) {
     this.contract = new ethers.Contract(address, DynamicPaymaster.abi, signer || provider);

--- a/services/secrets/envelope.ts
+++ b/services/secrets/envelope.ts
@@ -8,7 +8,7 @@ export interface KMS {
 }
 
 export class Envelope {
-  constructor(private kms: KMS) {}
+  constructor(private readonly kms: KMS) {}
 
   async encrypt(plaintext: Uint8Array) {
     const { plaintext: dek, ciphertext: dekWrapped } = await this.kms.generateDataKey();

--- a/services/telemetry/collector.ts
+++ b/services/telemetry/collector.ts
@@ -19,9 +19,9 @@ export interface TelemetryEvent {
 }
 
 export class TelemetryCollector {
-  private events: TelemetryEvent[] = [];
+  private readonly events: TelemetryEvent[] = [];
 
-  constructor(private serviceName: string) {}
+  constructor(private readonly serviceName: string) {}
 
   log(event: string, data: Record<string, any>, traceId?: string, spanId?: string) {
     const evt: TelemetryEvent = {
@@ -38,7 +38,7 @@ export class TelemetryCollector {
     return evt.traceId;
   }
 
-  async logOnChain(providerUrl: string, contractAddress: string, abi: any, fromBlock: number) {
+  async logOnChain(providerUrl: string, contractAddress: string, abi: any) {
     const provider = new ethers.JsonRpcProvider(providerUrl);
     const contract = new ethers.Contract(contractAddress, abi, provider);
 


### PR DESCRIPTION
## Summary
- mark stable fields as `readonly` across services and SDKs
- replace `any` unions with concrete types and add missing interfaces
- clean up unused imports and parameters

## Testing
- `pnpm exec eslint apps/billing-aa-service/src/bundler.ts apps/billing-aa-service/src/scheduler.ts apps/billing-aa-service/src/store.ts apps/checkout-sdk/src/index.ts apps/data/lineage-service/src/store.ts apps/pricing-service/src/engine/engine.ts apps/pricing-service/src/engine/lru.ts apps/pricing-service/src/store/audit.ts apps/search/rag-service/src/embeddings/local.ts apps/search/rag-service/src/embeddings/openai.ts apps/web/components/VariantsPanel.tsx mnt/data/gnew/packages/storage/src/multiRegionObjectStore.ts packages/checkout-sdk/src/fiat.ts packages/checkout-sdk/src/http.ts packages/checkout-sdk/src/subscriptions.ts packages/contracts/typechain-types/hardhat.d.ts packages/sdk/src/clients/antiCollusion.ts packages/sdk/src/clients/reviews.ts services/auth/passkeys/passkeyManager.ts services/data-governance/fieldEncryptor.ts services/finops/gasOptimizer.ts services/identity/m9-key-did-manager.ts services/identity/sybil-score.ts services/mev-guard/index.ts services/paymaster-sdk/index.ts services/secrets/envelope.ts services/telemetry/collector.ts`
- `pnpm test` *(fails: data-catalog-service and devrel-metrics tests)*

------
https://chatgpt.com/codex/tasks/task_e_68adf4b779d48326b6a32434a2d610cc