### PR TITLE
chore: improve ts immutability

### DIFF
--- a/apps/billing-aa-service/src/store.ts
+++ b/apps/billing-aa-service/src/store.ts
@@ -10,9 +10,9 @@ export type Job = {
 };
 
 export class JobsMemStore {
-  private watched = new Set<number>();
-  private q: Job[] = [];
-  private progress = new Set<string>();
+  private readonly watched = new Set<number>();
+  private readonly q: Job[] = [];
+  private readonly progress = new Set<string>();
   private done = 0;
   private failed = 0;
 

--- a/apps/checkout-sdk/src/index.ts
+++ b/apps/checkout-sdk/src/index.ts
@@ -16,7 +16,7 @@ import { signIntent, verifyWebhook } from "./utils/crypto";
 import type { CheckoutIntent, CheckoutOptions } from "./types";
 
 export class GnewCheckout {
-  private apiBase: string;
+  private readonly apiBase: string;
   constructor(apiBase: string) {
     this.apiBase = apiBase;
   }

--- a/apps/pricing-service/src/engine/engine.ts
+++ b/apps/pricing-service/src/engine/engine.ts
@@ -5,7 +5,7 @@ import { Ruleset, QuoteInput, QuoteResult, Rule, DiscountEffect } from "./types"
 import { RulesStore } from "../store/rules";
 
 export class PriceEngine {
-  private cache: LRU<string, QuoteResult>;
+  private readonly cache: LRU<string, QuoteResult>;
   constructor(private store: RulesStore) {
     const size = Number(process.env.CACHE_SIZE ?? 10_000);
     const ttl = Number(process.env.CACHE_TTL_MS ?? 60_000);

--- a/apps/pricing-service/src/engine/lru.ts
+++ b/apps/pricing-service/src/engine/lru.ts
@@ -1,8 +1,8 @@
 
 export class LRU<K, V> {
-  private max: number;
-  private ttlMs: number;
-  private map = new Map<K, { v: V; t: number }>();
+  private readonly max: number;
+  private readonly ttlMs: number;
+  private readonly map = new Map<K, { v: V; t: number }>();
 
   constructor(max = 5000, ttlMs = 60_000) {
     this.max = max;

--- a/apps/pricing-service/src/store/audit.ts
+++ b/apps/pricing-service/src/store/audit.ts
@@ -11,8 +11,8 @@ export type AuditEvent = {
 };
 
 export class AuditStore {
-  private file?: string;
-  private buf: AuditEvent[] = [];
+  private readonly file?: string;
+  private readonly buf: AuditEvent[] = [];
 
   constructor(filePath?: string) {
     if (filePath && filePath.trim().length > 0) {

--- a/apps/web/app/lib/voteCompareClient.ts
+++ b/apps/web/app/lib/voteCompareClient.ts
@@ -9,7 +9,35 @@ export type ComparePayload = {
   perturb_strength?: number;
 };
 
-export async function compareVariants(payload: ComparePayload): Promise<any> {
+export type CompareResponse = {
+  hash: string;
+  summary: Array<{
+    variant: string;
+    result: {
+      variant: string;
+      totals: Record<string, number>;
+      normTotals: Record<string, number>;
+      ranking: Array<{ optionId: string; score: number }>;
+      winner: string;
+    };
+    metrics: {
+      turnoutRate: number;
+      giniByOption: number;
+      top10Share: number;
+      decisiveMargin: number;
+      disagreementRate: number;
+      sybilSensitivity: number;
+    };
+    robustness: {
+      stability: number;
+      avgWinnerDelta: number;
+      flipRate: number;
+    };
+  }>;
+  options: Array<{ id: string; title: string }>;
+};
+
+export async function compareVariants(payload: ComparePayload): Promise<CompareResponse> {
   const res = await fetch("/api/variants/compare", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/web/components/VariantsPanel.tsx
+++ b/apps/web/components/VariantsPanel.tsx
@@ -1,8 +1,11 @@
 "use client"; 
  
-import { useMemo, useState } from "react"; 
-import { compareVariants, ComparePayload } from 
-"@/app/lib/voteCompareClient"; 
+import { useMemo, useState } from "react";
+import {
+  compareVariants,
+  ComparePayload,
+  CompareResponse,
+} from "@/app/lib/voteCompareClient";
 import { 
   ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend, 
 LineChart, Line, CartesianGrid, 
@@ -15,10 +18,10 @@ export default function VariantsPanel({ demo = false }: Readonly<{ demo?:
 boolean }>) {
   const [loading, setLoading] = useState(false); 
   const [err, setErr] = useState<string | null>(null); 
-  const [data, setData] = useState<any | null>(null); 
+  const [data, setData] = useState<CompareResponse | null>(null);
  
-  const payload: ComparePayload = useMemo(() => { 
-    if (!demo) return { options: [], voters: [], ballots: [] } as any; 
+  const payload: ComparePayload = useMemo(() => {
+    if (!demo) return { options: [], voters: [], ballots: [] };
  
     // Dataset de ejemplo: 4 opciones, 120 votantes en 3 segmentos 
     const options = [ 
@@ -77,32 +80,32 @@ Math.random() * 86400e3 };
   const barsData = useMemo(() => { 
     if (!data) return []; 
     // dataset para barras: score normalizado por opción y variante 
-    const rows: Array<any> = []; 
-    for (const op of data.options) { 
-      const row: any = { option: op.title }; 
-      for (const s of data.summary) { 
-        row[s.variant] = Number((s.result.normTotals[op.id] * 
-100).toFixed(2)); 
-      } 
-      rows.push(row); 
-    } 
-    return rows; 
-  }, [data]); 
- 
-  const metricsData = useMemo(() => { 
-    if (!data) return []; 
-    return data.summary.map((s: any) => ({ 
-      variant: s.variant, 
-      turnout: Number((s.metrics.turnoutRate * 100).toFixed(1)), 
-      gini: Number(s.metrics.giniByOption.toFixed(3)), 
-      top10: Number((s.metrics.top10Share * 100).toFixed(1)), 
-      margin: Number((s.metrics.decisiveMargin * 100).toFixed(1)), 
-      disagree: Number((s.metrics.disagreementRate * 100).toFixed(1)), 
-      sybil: Number((s.metrics.sybilSensitivity * 100).toFixed(2)), 
-      stability: Number((s.robustness.stability * 100).toFixed(1)), 
-      flip: Number((s.robustness.flipRate * 100).toFixed(1)), 
-    })); 
-  }, [data]); 
+    const rows: Array<Record<string, number | string>> = [];
+    for (const op of data.options) {
+      const row: Record<string, number | string> = { option: op.title };
+      for (const s of data.summary) {
+        row[s.variant] = Number((s.result.normTotals[op.id] *
+100).toFixed(2));
+      }
+      rows.push(row);
+    }
+    return rows;
+  }, [data]);
+
+  const metricsData = useMemo(() => {
+    if (!data) return [];
+    return data.summary.map((s) => ({
+      variant: s.variant,
+      turnout: Number((s.metrics.turnoutRate * 100).toFixed(1)),
+      gini: Number(s.metrics.giniByOption.toFixed(3)),
+      top10: Number((s.metrics.top10Share * 100).toFixed(1)),
+      margin: Number((s.metrics.decisiveMargin * 100).toFixed(1)),
+      disagree: Number((s.metrics.disagreementRate * 100).toFixed(1)),
+      sybil: Number((s.metrics.sybilSensitivity * 100).toFixed(2)),
+      stability: Number((s.robustness.stability * 100).toFixed(1)),
+      flip: Number((s.robustness.flipRate * 100).toFixed(1)),
+    }));
+  }, [data]);
  
   return ( 
     <section className="rounded-2xl border p-4 md:p-6 bg-white 

--- a/docs/treasury/N106-programmable-treasury.md
+++ b/docs/treasury/N106-programmable-treasury.md
@@ -518,7 +518,8 @@ def bps(a: float, b: float) -> float:
 if a == 0 or b == 0: return float("inf") 
 return abs(a - b) / ((a + b) / 2) * 10000.0 
 Ruta completa: ./services/pricing_oracle/onchain.py 
-from web3 import Web3 
+from web3 import Web3
+from web3.contract import Contract
 from eth_account.messages import encode_defunct 
 from dataclasses import dataclass 
 SIGNED_ABI = 
@@ -544,10 +545,10 @@ CL_ABI =
  "function"}]' 
 @dataclass 
 class Chain: 
-w3: Web3 
-oracle: any 
-cl: any | None 
-pk: str | None 
+w3: Web3
+oracle: Contract
+cl: Contract | None
+pk: str | None
 def connect(rpc_url: str, signed_addr: str, cl_addr: str | None, 
 chain_id: int, pk: str | None) -> Chain: 
 w3 = Web3(Web3.HTTPProvider(rpc_url, request_kwargs={"timeout": 

--- a/mnt/data/gnew/packages/storage/src/multiRegionObjectStore.ts
+++ b/mnt/data/gnew/packages/storage/src/multiRegionObjectStore.ts
@@ -14,8 +14,8 @@ interface MultiRegionObjectStoreOptions {
 }
 
 export class MultiRegionObjectStore {
-  private primary: RegionConfig;
-  private replicas: RegionConfig[];
+  private readonly primary: RegionConfig;
+  private readonly replicas: RegionConfig[];
 
   constructor(options: MultiRegionObjectStoreOptions) {
     this.primary = options.primary;

--- a/packages/checkout-sdk/src/fiat.ts
+++ b/packages/checkout-sdk/src/fiat.ts
@@ -3,7 +3,7 @@ import { Http } from "./http.js";
 import type { QuoteReq, Quote, CreateOrderParams, Order } from "./types.js";
 
 export class FiatRampClient {
-  private http: Http;
+  private readonly http: Http;
   constructor(opts: { baseUrl: string; timeoutMs?: number }) {
     this.http = new Http(opts.baseUrl, opts.timeoutMs);
   }

--- a/packages/checkout-sdk/src/subscriptions.ts
+++ b/packages/checkout-sdk/src/subscriptions.ts
@@ -6,7 +6,7 @@ import type {
 } from "./types.js";
 
 export class SubscriptionsClient {
-  private http: Http;
+  private readonly http: Http;
   constructor(opts: { baseUrl: string; timeoutMs?: number }) {
     this.http = new Http(opts.baseUrl, opts.timeoutMs);
   }

--- a/services/auth/passkeys/passkeyManager.ts
+++ b/services/auth/passkeys/passkeyManager.ts
@@ -23,7 +23,7 @@ export interface AuthenticationOptions {
 }
 
 export class PasskeyManager {
-  private store: Map<string, any> = new Map();
+  private readonly store: Map<string, any> = new Map();
 
   generateRegistrationOptions(userId: string, username: string): RegistrationOptions {
     const challenge = generateChallenge();

--- a/services/data-governance/fieldEncryptor.ts
+++ b/services/data-governance/fieldEncryptor.ts
@@ -15,8 +15,8 @@ interface FieldPolicy {
 const ALGORITHM = "aes-256-gcm";
 
 export class FieldEncryptor {
-  private key: Buffer;
-  private policies: Record<string, FieldPolicy> = {};
+  private readonly key: Buffer;
+  private readonly policies: Record<string, FieldPolicy> = {};
 
   constructor(secret: string) {
     this.key = crypto.createHash("sha256").update(secret).digest();

--- a/services/finops/gasOptimizer.ts
+++ b/services/finops/gasOptimizer.ts
@@ -14,7 +14,7 @@ export interface GasEstimation {
 }
 
 export class GasOptimizer {
-  private provider: ethers.JsonRpcProvider;
+  private readonly provider: ethers.JsonRpcProvider;
 
   constructor(rpcUrl: string) {
     this.provider = new ethers.JsonRpcProvider(rpcUrl);

--- a/services/identity/m9-key-did-manager.ts
+++ b/services/identity/m9-key-did-manager.ts
@@ -25,7 +25,7 @@ class MPCStub {
 }
 
 export class DIDManager {
-  private docs: Map<string, DIDDocument> = new Map();
+  private readonly docs: Map<string, DIDDocument> = new Map();
 
   createDID(): DIDDocument {
     const pubKey = MPCStub.generateKey();

--- a/services/identity/sybil-score.ts
+++ b/services/identity/sybil-score.ts
@@ -15,7 +15,7 @@ interface SybilSignal {
 }
 
 export class SybilScorer {
-  private driver: Driver;
+  private readonly driver: Driver;
 
   constructor(uri: string, user: string, password: string) {
     this.driver = neo4j.driver(uri, neo4j.auth.basic(user, password));

--- a/services/mev-guard/index.ts
+++ b/services/mev-guard/index.ts
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 import FairOrdering from "../../artifacts/contracts/mev/FairOrdering.sol/FairOrdering.json";
 
 export class MevGuardSDK {
-  private contract: ethers.Contract;
+  private readonly contract: ethers.Contract;
 
   constructor(address: string, provider: ethers.JsonRpcProvider, signer?: ethers.Signer) {
     this.contract = new ethers.Contract(address, FairOrdering.abi, signer || provider);

--- a/services/paymaster-sdk/index.ts
+++ b/services/paymaster-sdk/index.ts
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 import DynamicPaymaster from "../../artifacts/contracts/paymasters/DynamicPaymaster.sol/DynamicPaymaster.json";
 
 export class PaymasterSDK {
-  private contract: ethers.Contract;
+  private readonly contract: ethers.Contract;
 
   constructor(address: string, provider: ethers.JsonRpcProvider, signer?: ethers.Signer) {
     this.contract = new ethers.Contract(address, DynamicPaymaster.abi, signer || provider);

--- a/services/telemetry/collector.ts
+++ b/services/telemetry/collector.ts
@@ -19,7 +19,7 @@ export interface TelemetryEvent {
 }
 
 export class TelemetryCollector {
-  private events: TelemetryEvent[] = [];
+  private readonly events: TelemetryEvent[] = [];
 
   constructor(private serviceName: string) {}
 


### PR DESCRIPTION
## Summary
- mark immutable fields as readonly across services and SDKs
- replace `any` unions with concrete types
- type vote comparison client and panel

## Testing
- `pnpm lint` *(fails: Cannot read config file: gnew/devrel/quickstarts/node-basic/package.json)*
- `pnpm test` *(fails: apps/data-catalog-service tests missing Jest globals)*

------
https://chatgpt.com/codex/tasks/task_e_68ae31ca6b188326a912af5998f384e6