### PR TITLE
chore(ci): add YAML linting workflow and fix deploy strategy

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,27 @@
+name: ci-lint
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install yamllint
+        run: pip install yamllint
+      - name: Run yamllint
+        run: yamllint .
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1

--- a/.github/workflows/deploy-strategy.yml
+++ b/.github/workflows/deploy-strategy.yml
@@ -4,13 +4,16 @@ on:
     inputs:
       service:
         description: "Servicio"
-        type: string
         required: true
+        type: string
       environment:
         description: "Entorno (dev|staging|prod)"
-        type: choice
-        options: [dev, staging, prod]
         required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
         default: dev
 
 jobs:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
## Summary
- fix Deploy Strategy workflow inputs indentation
- add yamllint config and CI lint workflow with yamllint and actionlint

## Testing
- `yamllint .` *(fails: command not found)*
- `actionlint` *(fails: command not found)*
- `act -n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae327f4ab48326acfe689e6604eacf