### PR TITLE
fix: use stable ids for thread messages

### DIFF
--- a/apps/community-forum/src/pages/threads/[id].tsx
+++ b/apps/community-forum/src/pages/threads/[id].tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useRouter } from "next/router";
 import useSWR from "swr";
 
@@ -13,10 +14,10 @@ export default function ThreadPage() {
       <h1 className="text-2xl font-bold mb-4">{data.title}</h1>
       <p className="text-sm text-gray-500">By {data.author}</p>
       <div className="mt-4 space-y-2">
-        {data.posts.map((p: any) => (
-          <div key={`${p.author}-${p.content}`} className="border p-2 rounded">
-            <p>{p.content}</p>
-            <p className="text-xs text-gray-500">— {p.author}</p>
+        {data.posts.map((message: any) => (
+          <div key={message.id} className="border p-2 rounded">
+            <p>{message.content}</p>
+            <p className="text-xs text-gray-500">— {message.author}</p>
           </div>
         ))}
       </div>

--- a/apps/community-forum/tests/__snapshots__/thread-page.test.tsx.snap
+++ b/apps/community-forum/tests/__snapshots__/thread-page.test.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`thread page snapshot 1`] = `"<main class="max-w-2xl mx-auto p-4"><h1 class="text-2xl font-bold mb-4">Test Thread</h1><p class="text-sm text-gray-500">By <!-- -->Tester</p><div class="mt-4 space-y-2"><div class="border p-2 rounded"><p>First message</p><p class="text-xs text-gray-500">— <!-- -->Alice</p></div><div class="border p-2 rounded"><p>Second message</p><p class="text-xs text-gray-500">— <!-- -->Bob</p></div></div></main>"`;

--- a/apps/community-forum/tests/thread-page.test.tsx
+++ b/apps/community-forum/tests/thread-page.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { test, expect, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import ThreadPage from "../src/pages/threads/[id]";
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { id: "1" } })
+}));
+
+vi.mock("swr", () => ({
+  default: () => ({
+    data: {
+      title: "Test Thread",
+      author: "Tester",
+      posts: [
+        { id: "msg-1", content: "First message", author: "Alice" },
+        { id: "msg-2", content: "Second message", author: "Bob" }
+      ]
+    },
+    error: null
+  })
+}));
+
+test("thread page snapshot", () => {
+  const html = renderToString(<ThreadPage />);
+  expect(html).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary
- use message id for React list keys in thread page to satisfy Sonar rule S6479
- add snapshot test for thread page

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae33128db4832694045cb409b69942