### PR TITLE
refactor: strengthen data catalog typing and errors

### DIFF
--- a/apps/data-catalog-service/tests/index.test.ts
+++ b/apps/data-catalog-service/tests/index.test.ts
@@ -142,6 +142,11 @@ describe("data-catalog-service", () => {
     expect(urns).not.toContain("urn:li:dataset:(urn:li:dataPlatform:hive,db.tbl2,PROD)");
   });
 
+  it("search missing query returns 400", async () => {
+    const res = await request(server).get("/search").set("Authorization", `Bearer ${userSales}`);
+    expect(res.status).toBe(400);
+  });
+
   it("search denies when dept mismatch for internal", async () => {
     const res = await request(server).get("/search?q=orders").set("Authorization", `Bearer ${userOther}`);
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- refine JWT auth with proper typing and structured logging
- harden DataHub client and search query normalization
- add integration test for missing search query

## Testing
- `pnpm --filter @gnew/data-catalog-service test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3321be6c832681a3f688a985656a