### PR TITLE
Governance UI: improve DelegationCard accessibility and tests

### DIFF
--- a/apps/governance-ui/package.json
+++ b/apps/governance-ui/package.json
@@ -3,20 +3,26 @@
   "version": "0.1.0", 
   "private": true, 
   "type": "module", 
-  "scripts": { 
-    "dev": "vite", 
-    "build": "vite build", 
-    "preview": "vite preview" 
-  }, 
-  "dependencies": { 
-    "ethers": "^6.13.0", 
-    "react": "^18.3.1", 
-    "react-dom": "^18.3.1" 
-}, 
-"devDependencies": { 
-"@types/react": "^18.3.3", 
-"@types/react-dom": "^18.3.0", 
-"typescript": "^5.5.4", 
-"vite": "^5.4.2" 
-} 
-} 
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "ethers": "^6.13.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5",
+    "vitest-axe": "^0.8.0"
+  }
+}

--- a/apps/governance-ui/src/components/DelegationCard.tsx
+++ b/apps/governance-ui/src/components/DelegationCard.tsx
@@ -1,164 +1,182 @@
-import React, { useEffect, useMemo, useState } from "react"; 
-import { BrowserProvider, Contract, Eip1193Provider, ethers, type InterfaceAbi } from "ethers"; 
-import DelegationAbi from "../abis/delegation"; 
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  BrowserProvider,
+  Contract,
+  Eip1193Provider,
+  ethers,
+  type InterfaceAbi,
+} from "ethers";
+import DelegationAbi from "../abis/delegation";
+
 type Props = Readonly<{
-contractAddress: string;
-scopeLabel?: string; // p.ej. "TOKEN_VOTES" | "REPUTATION_VOTES"
+  contractAddress: string;
+  scopeLabel?: string; // p.ej. "TOKEN_VOTES" | "REPUTATION_VOTES"
 }>;
-function toBytes32(label: string) { 
-return ethers.id(label); 
-} 
-export default function DelegationCard({ contractAddress, scopeLabel = 
-"TOKEN_VOTES" }: Props) { 
-const [provider, setProvider] = useState<BrowserProvider | 
-null>(null); 
-const [account, setAccount] = useState<string>(""); 
-const [delegatee, setDelegatee] = useState<string>(""); 
-const [expiresAt, setExpiresAt] = useState<string>(""); // ISO datetime-local input value
-const [status, setStatus] = useState<{ effective: string; active: 
-boolean; exp: bigint } | null>(null); 
-const [loading, setLoading] = useState(false); 
- 
-  const scope = useMemo(() => toBytes32(scopeLabel), [scopeLabel]); 
- 
-  useEffect(() => { 
-    const eth = (window as unknown as { ethereum?: Eip1193Provider }).ethereum; 
-    if (!eth) return; 
-    const p = new BrowserProvider(eth); 
-    setProvider(p); 
-    (async () => { 
-      const [addr] = await eth.request!({ method: "eth_requestAccounts" }); 
-      setAccount(addr); 
-    })(); 
-  }, []); 
- 
-  async function readStatus() { 
-    if (!provider) return; 
-  const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, await 
-provider.getSigner()); 
-    const [effective, active, exp] = await 
-c.effectiveDelegateOf(account, scope); 
-    setStatus({ effective, active, exp }); 
-  } 
- 
-  useEffect(() => { 
-    if (provider && account) readStatus().catch(console.error); 
-  }, [provider, account, scope]); 
- 
-  async function onDelegate() { 
-    if (!provider) return; 
-    setLoading(true); 
-    try { 
-      const signer = await provider.getSigner(); 
-  const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, 
-signer); 
-      const expTs = 
-        expiresAt && expiresAt.length 
-          ? Math.floor(new Date(expiresAt).getTime() / 1000) 
-          : 0; 
-      const tx = await c.delegate(scope, delegatee, expTs); 
-      await tx.wait(); 
-      setDelegatee(""); 
-      setExpiresAt(""); 
-      await readStatus(); 
-    } finally { 
-      setLoading(false); 
-    } 
-  } 
- 
-  async function onExtend(newIso?: string) { 
-    if (!provider) return; 
-    setLoading(true); 
-    try { 
-      const signer = await provider.getSigner(); 
-  const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, 
-signer); 
-      const expTs = 
-        newIso && newIso.length ? Math.floor(new 
-Date(newIso).getTime() / 1000) : 0; 
-      const tx = await c.extend(scope, expTs); 
-      await tx.wait(); 
-      await readStatus(); 
-    } finally { 
-      setLoading(false); 
-    } 
-  } 
- 
-  async function onRevoke() { 
-    if (!provider) return; 
-    setLoading(true); 
-    try { 
-      const signer = await provider.getSigner(); 
-  const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, 
-signer); 
-      const tx = await c.revoke(scope); 
-      await tx.wait(); 
-      await readStatus(); 
-    } finally { 
-      setLoading(false); 
-    } 
-  } 
- 
-  return ( 
-    <div className="max-w-xl rounded-2xl p-4 shadow border"> 
-      <h2 className="text-xl font-semibold mb-2">Delegación — 
-{scopeLabel}</h2> 
-      <div className="text-sm mb-3"> 
-        <div><b>Cuenta:</b> {account || "—"}</div> 
-        <div><b>Delegado efectivo:</b> {status ? status.effective : 
-"…"} {status?.active ? "(activo)" : "(—)"}</div> 
-        <div> 
-          <b>Expira:</b>{" "} 
-          {status 
-            ? status.exp === 0n 
-              ? "sin expiración" 
-              : new Date(Number(status.exp) * 1000).toLocaleString() 
-            : "…"} 
-        </div> 
-      </div> 
- 
-      <div className="grid gap-2"> 
-        <input 
-          className="border rounded p-2" 
-          placeholder="0xDelegatee" 
-          value={delegatee} 
-          onChange={(e) => setDelegatee(e.target.value)} 
-        /> 
-        <label className="text-xs opacity-70">Expiración 
-(opcional):</label> 
-        <input 
-          type="datetime-local" 
-          className="border rounded p-2" 
-          value={expiresAt} 
-          onChange={(e) => setExpiresAt(e.target.value)} 
-        /> 
-        <div className="flex gap-2 mt-2"> 
-          <button 
-            disabled={loading || !delegatee} 
-            onClick={onDelegate} 
-            className="px-3 py-2 rounded bg-black text-white 
-disabled:opacity-50" 
-          > 
-            {status?.active ? "Reasignar" : "Delegar"} 
-          </button> 
-          <button 
-            disabled={loading || !status?.active} 
-            onClick={() => onExtend("")} 
-            className="px-3 py-2 rounded border" 
-            title="Quita la expiración (permanente hasta revocar)" 
-          > 
-            Quitar expiración 
-          </button> 
-          <button 
-            disabled={loading || !status?.active} 
-            onClick={onRevoke} 
-            className="px-3 py-2 rounded border" 
-          > 
-            Revocar 
-          </button> 
-        </div> 
-      </div> 
-    </div> 
-  ); 
-} 
- 
+
+function toBytes32(label: string) {
+  return ethers.id(label);
+}
+
+function formatExpiration(exp?: bigint) {
+  if (exp === undefined) return "…";
+  if (exp === 0n) return "sin expiración";
+  return new Date(Number(exp) * 1000).toLocaleString();
+}
+
+function activeLabel(active?: boolean) {
+  return active ? "(activo)" : "(—)";
+}
+
+export default function DelegationCard({
+  contractAddress,
+  scopeLabel = "TOKEN_VOTES",
+}: Props) {
+  const [provider, setProvider] = useState<BrowserProvider | null>(null);
+  const [account, setAccount] = useState("");
+  const [delegatee, setDelegatee] = useState("");
+  const [expiresAt, setExpiresAt] = useState(""); // ISO datetime-local input value
+  const [status, setStatus] = useState<{ effective: string; active: boolean; exp: bigint } | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+
+  const scope = useMemo(() => toBytes32(scopeLabel), [scopeLabel]);
+
+  useEffect(() => {
+    const eth = (window as unknown as { ethereum?: Eip1193Provider }).ethereum;
+    if (!eth) return;
+    const p = new BrowserProvider(eth);
+    setProvider(p);
+    (async () => {
+      const [addr] = await eth.request!({ method: "eth_requestAccounts" });
+      setAccount(addr);
+    })();
+  }, []);
+
+  async function readStatus() {
+    if (!provider) return;
+    const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, await provider.getSigner());
+    const [effective, active, exp] = await c.effectiveDelegateOf(account, scope);
+    setStatus({ effective, active, exp });
+  }
+
+  useEffect(() => {
+    if (provider && account) readStatus().catch(console.error);
+  }, [provider, account, scope]);
+
+  async function onDelegate() {
+    if (!provider) return;
+    setLoading(true);
+    try {
+      const signer = await provider.getSigner();
+      const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, signer);
+      const expTs = expiresAt && expiresAt.length ? Math.floor(new Date(expiresAt).getTime() / 1000) : 0;
+      const tx = await c.delegate(scope, delegatee, expTs);
+      await tx.wait();
+      setDelegatee("");
+      setExpiresAt("");
+      await readStatus();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onExtend(newIso?: string) {
+    if (!provider) return;
+    setLoading(true);
+    try {
+      const signer = await provider.getSigner();
+      const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, signer);
+      const expTs = newIso && newIso.length ? Math.floor(new Date(newIso).getTime() / 1000) : 0;
+      const tx = await c.extend(scope, expTs);
+      await tx.wait();
+      await readStatus();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onRevoke() {
+    if (!provider) return;
+    setLoading(true);
+    try {
+      const signer = await provider.getSigner();
+      const c = new Contract(contractAddress, DelegationAbi as InterfaceAbi, signer);
+      const tx = await c.revoke(scope);
+      await tx.wait();
+      await readStatus();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const delegateEffective = status ? status.effective : "…";
+  const activeText = activeLabel(status?.active);
+  const expirationText = formatExpiration(status?.exp);
+  const delegateButtonText = status?.active ? "Reasignar" : "Delegar";
+
+  return (
+    <div className="max-w-xl rounded-2xl p-4 shadow border">
+      <h2 className="text-xl font-semibold mb-2">Delegación — {scopeLabel}</h2>
+      <div className="text-sm mb-3">
+        <div>
+          <b>Cuenta:</b> {account || "—"}
+        </div>
+        <div>
+          <b>Delegado efectivo:</b> {delegateEffective} {activeText}
+        </div>
+        <div>
+          <b>Expira:</b> {expirationText}
+        </div>
+      </div>
+
+      <div className="grid gap-2">
+        <label htmlFor="delegatee" className="text-xs opacity-70">
+          Delegado
+        </label>
+        <input
+          id="delegatee"
+          className="border rounded p-2"
+          placeholder="0xDelegatee"
+          value={delegatee}
+          onChange={(e) => setDelegatee(e.target.value)}
+        />
+        <label htmlFor="expiration" className="text-xs opacity-70">
+          Expiración (opcional)
+        </label>
+        <input
+          id="expiration"
+          type="datetime-local"
+          className="border rounded p-2"
+          value={expiresAt}
+          onChange={(e) => setExpiresAt(e.target.value)}
+        />
+        <div className="flex gap-2 mt-2">
+          <button
+            disabled={loading || !delegatee}
+            onClick={onDelegate}
+            className="px-3 py-2 rounded bg-black text-white disabled:opacity-50"
+          >
+            {delegateButtonText}
+          </button>
+          <button
+            disabled={loading || !status?.active}
+            onClick={() => onExtend("")}
+            className="px-3 py-2 rounded border"
+            title="Quita la expiración (permanente hasta revocar)"
+          >
+            Quitar expiración
+          </button>
+          <button
+            disabled={loading || !status?.active}
+            onClick={onRevoke}
+            className="px-3 py-2 rounded border"
+          >
+            Revocar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/governance-ui/tests/DelegationCard.test.tsx
+++ b/apps/governance-ui/tests/DelegationCard.test.tsx
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "vitest-axe";
+import { describe, expect, it } from "vitest";
+import React from "react";
+import DelegationCard from "../src/components/DelegationCard";
+
+expect.extend(toHaveNoViolations);
+
+describe("DelegationCard", () => {
+  it("links labels to inputs", () => {
+    render(<DelegationCard contractAddress="0x0" />);
+    expect(screen.getByLabelText("Delegado")).toBeInTheDocument();
+    expect(screen.getByLabelText("Expiración (opcional)")).toBeInTheDocument();
+  });
+
+  it("is accessible", async () => {
+    const { container } = render(<DelegationCard contractAddress="0x0" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+

--- a/apps/governance-ui/vitest.config.ts
+++ b/apps/governance-ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});
+


### PR DESCRIPTION
## Summary
- refactor DelegationCard component to reduce ternaries and add helper functions
- associate labels with inputs and precompute UI state
- add vitest config and axe-based tests

## Testing
- `pnpm --filter @gnew/governance-ui test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3342cb3083269998a6c4fe021d30