### PR TITLE
feat: secure ledger DB config and query params

### DIFF
--- a/apps/ledger-service/.env.example
+++ b/apps/ledger-service/.env.example
@@ -1,6 +1,8 @@
 
 PORT=8093
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/gnew_ledger
+DATABASE_URL=vault://kv/data/apps/ledger-service/db-url
+VAULT_ADDR=http://127.0.0.1:8200
+VAULT_TOKEN=
 LOG_LEVEL=info
 APPLY_TRIGGERS=true
 

--- a/policies/ledger-service.hcl
+++ b/policies/ledger-service.hcl
@@ -1,0 +1,11 @@
+path "kv/data/apps/ledger-service/*" {
+  capabilities = ["read"]
+}
+
+path "kv/metadata/apps/ledger-service/*" {
+  capabilities = ["read"]
+}
+
+path "*" {
+  capabilities = []
+}


### PR DESCRIPTION
## Summary
- remove hardcoded Postgres URL and resolve DATABASE_URL from env or Vault
- use optional chaining and safe string coercion for query params
- add Vault policy and example env configuration

## Testing
- `pnpm -F @gnew/ledger-service test` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ae33525b7c832699cb6536d27d2012