### PR TITLE
refactor observability index

### DIFF
--- a/apps/observability/package.json
+++ b/apps/observability/package.json
@@ -3,24 +3,27 @@
 "version": "0.1.0", 
 "private": true, 
 "type": "module", 
-"scripts": { 
-"dev": "tsx src/index.ts", 
-"build": "tsc -p tsconfig.json", 
-"start": "node dist/index.js", 
-"lint": "eslint . --ext .ts", 
-"format": "prettier --write ." 
-}, 
-"dependencies": { 
-    "dotenv": "^16.4.5", 
-    "ethers": "^6.13.0", 
-    "fastify": "^4.28.1", 
-    "prom-client": "^15.1.3", 
-    "zod": "^3.23.8" 
-  }, 
-  "devDependencies": { 
-    "@types/node": "^20.14.9", 
-    "tsx": "^4.16.2", 
-    "typescript": "^5.5.4" 
-  } 
-} 
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "ethers": "^6.13.0",
+    "fastify": "^4.28.1",
+    "prom-client": "^15.1.3",
+    "zod": "^3.23.8",
+    "pino": "^9.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  }
+}
  

--- a/apps/observability/tests/processTransactions.test.ts
+++ b/apps/observability/tests/processTransactions.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+process.env.RPC_URL = "http://localhost:8545";
+process.env.CHAIN_ID = "1";
+process.env.CONTRACTS = "GnewToken:0x1111111111111111111111111111111111111111";
+
+const mod = await import("../src/index");
+const { processTransactions, cTxTotal, cTxFailed } = mod;
+
+beforeEach(() => {
+  cTxTotal.reset();
+  cTxFailed.reset();
+});
+
+test("processTransactions updates metrics", async () => {
+  const fakeProvider = {
+    getBlock: vi.fn().mockResolvedValue({
+      transactions: [
+        { to: "0x1111111111111111111111111111111111111111", hash: "0x1" },
+        { to: "0x2222222222222222222222222222222222222222", hash: "0x2" }
+      ]
+    }),
+    getTransactionReceipt: vi.fn()
+      .mockResolvedValueOnce({ status: 0 })
+      .mockResolvedValue({ status: 1 })
+  } as any;
+
+  await processTransactions(1, 1, fakeProvider);
+
+  const total = cTxTotal.get().values.find((v: any) => v.labels.contract === "GnewToken")?.value ?? 0;
+  const failed = cTxFailed.get().values.find((v: any) => v.labels.contract === "GnewToken")?.value ?? 0;
+  expect(total).toBe(1);
+  expect(failed).toBe(1);
+});


### PR DESCRIPTION
## Summary
- reduce poller complexity by splitting log and transaction processing
- replace console with pino logger and contextual error handling
- add webhook address normalization and basic transaction metric test

## Testing
- `pnpm test --filter @gnew/observability` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae335ff1788326a3e22f3f2e78e2f8