### PR TITLE
feat(sdk): enforce readonly deps and inject fetch

### DIFF
--- a/packages/sdk/__tests__/antiCollusion.test.ts
+++ b/packages/sdk/__tests__/antiCollusion.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { AntiCollusionClient } from "../src/clients/antiCollusion";
+
+describe("AntiCollusionClient", () => {
+  it("uses injected fetch and includes auth header", async () => {
+    const mockFetch = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true }) }));
+    const client = new AntiCollusionClient("https://api.test", "token", mockFetch as any);
+    await client.run();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.test/run",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+      })
+    );
+  });
+});

--- a/packages/sdk/__tests__/reviews.test.ts
+++ b/packages/sdk/__tests__/reviews.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import { ReviewsClient, ReviewPayload } from "../src/clients/reviews";
+
+describe("ReviewsClient", () => {
+  it("submits review using injected fetch and headers", async () => {
+    const mockFetch = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true }) }));
+    const client = new ReviewsClient("https://api.test", "secret", mockFetch as any);
+    const payload: ReviewPayload = { slug: "proj", address: "0x1", rating: 5, content: "Great" };
+    await client.submitReview(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.test/reviews/submit",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer secret" }),
+        body: JSON.stringify(payload),
+      })
+    );
+  });
+});

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": { "build": "tsc -p tsconfig.json" },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
   "dependencies": {
     "ethers": "^6.13.2"
   },

--- a/packages/sdk/src/clients/antiCollusion.ts
+++ b/packages/sdk/src/clients/antiCollusion.ts
@@ -1,16 +1,20 @@
 export type LabelItem = { kind: "group" | "user"; key: string | number; y: 0 | 1 };
 
 export class AntiCollusionClient {
-  constructor(private baseUrl: string, private token?: string) {}
-  private h() {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token?: string,
+    private readonly fetchFn: typeof fetch = fetch
+  ) {}
+  private h(): Record<string, string> {
     return {
       "Content-Type": "application/json",
       ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
     } as Record<string, string>;
   }
 
-  async ingestVotes(rows: { address: string; target: string; ts: string; value?: number; meta?: any }[]) {
-    const r = await fetch(`${this.baseUrl}/etl/votes`, {
+  async ingestVotes(rows: { address: string; target: string; ts: string; value?: number; meta?: any }[]): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/etl/votes`, {
       method: "POST",
       headers: this.h(),
       body: JSON.stringify({ rows }),
@@ -19,8 +23,8 @@ export class AntiCollusionClient {
     return r.json();
   }
 
-  async label(items: LabelItem[]) {
-    const r = await fetch(`${this.baseUrl}/labels`, {
+  async label(items: LabelItem[]): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/labels`, {
       method: "POST",
       headers: this.h(),
       body: JSON.stringify({ items }),
@@ -29,20 +33,20 @@ export class AntiCollusionClient {
     return r.json();
   }
 
-  async run() {
-    const r = await fetch(`${this.baseUrl}/run`, { method: "POST", headers: this.h(), body: JSON.stringify({}) });
+  async run(): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/run`, { method: "POST", headers: this.h(), body: JSON.stringify({}) });
     if (!r.ok) throw new Error(`run failed ${r.status}`);
     return r.json();
   }
 
-  async groups(batch_id: string) {
-    const r = await fetch(`${this.baseUrl}/groups/${batch_id}`, { headers: this.h() });
+  async groups(batch_id: string): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/groups/${batch_id}`, { headers: this.h() });
     if (!r.ok) throw new Error(`groups failed ${r.status}`);
     return r.json();
   }
 
-  async dodStatus() {
-    const r = await fetch(`${this.baseUrl}/dod/status`, { headers: this.h() });
+  async dodStatus(): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/dod/status`, { headers: this.h() });
     if (!r.ok) throw new Error(`status failed ${r.status}`);
     return r.json();
   }

--- a/packages/sdk/src/clients/reviews.ts
+++ b/packages/sdk/src/clients/reviews.ts
@@ -9,34 +9,38 @@ export type ReviewPayload = {
 };
 
 export class ReviewsClient {
-  constructor(private baseUrl: string, private token?: string) {}
-  private h() {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token?: string,
+    private readonly fetchFn: typeof fetch = fetch
+  ) {}
+  private h(): Record<string, string> {
     return {
       "Content-Type": "application/json",
       ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
     } as Record<string, string>;
   }
 
-  async submitReview(p: ReviewPayload) {
-    const r = await fetch(`${this.baseUrl}/reviews/submit`, { method: "POST", headers: this.h(), body: JSON.stringify(p) });
+  async submitReview(p: ReviewPayload): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/reviews/submit`, { method: "POST", headers: this.h(), body: JSON.stringify(p) });
     if (!r.ok) throw new Error(`submit failed ${r.status}`);
     return r.json();
   }
 
-  async recompute(slug: string) {
-    const r = await fetch(`${this.baseUrl}/projects/${slug}/recompute`, { method: "POST", headers: this.h() });
+  async recompute(slug: string): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/projects/${slug}/recompute`, { method: "POST", headers: this.h() });
     if (!r.ok) throw new Error(`recompute failed ${r.status}`);
     return r.json();
   }
 
-  async explain(review_id: number) {
-    const r = await fetch(`${this.baseUrl}/reviews/${review_id}/explain`, { headers: this.h() });
+  async explain(review_id: number): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/reviews/${review_id}/explain`, { headers: this.h() });
     if (!r.ok) throw new Error(`explain failed ${r.status}`);
     return r.json();
   }
 
-  async rag(slug: string, q: string) {
-    const r = await fetch(`${this.baseUrl}/projects/${slug}/reviews/rag?q=${encodeURIComponent(q)}`, { headers: this.h() });
+  async rag(slug: string, q: string): Promise<unknown> {
+    const r = await this.fetchFn(`${this.baseUrl}/projects/${slug}/reviews/rag?q=${encodeURIComponent(q)}`, { headers: this.h() });
     if (!r.ok) throw new Error(`rag failed ${r.status}`);
     return r.json();
   }


### PR DESCRIPTION
## Summary
- make AntiCollusionClient and ReviewsClient immutable and allow custom fetch injection
- cover clients with tests for authorization header and dependency injection

## Testing
- `pnpm --filter @gnew/sdk test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae33a697508326816c933d3b31bd6a