### PR TITLE
refactor: improve treasury CLI typing

### DIFF
--- a/packages/treasury-cli/package.json
+++ b/packages/treasury-cli/package.json
@@ -6,30 +6,32 @@
   "bin": { 
     "gnew-treasury": "dist/index.js" 
   }, 
-  "scripts": { 
-    "build": "tsc -p tsconfig.json", 
-    "dev": "tsx src/index.ts", 
-    "lint": "eslint . --max-warnings=0", 
-    "propose:eth": "tsx src/proposeTransfer.ts", 
-    "propose:erc20": "tsx src/proposeErc20.ts", 
-    "opa:test": "opa test ../treasury-policies -v" 
-  }, 
-  "dependencies": { 
-    "@safe-global/protocol-kit": "^5.0.1", 
-    "@safe-global/api-kit": "^3.0.2", 
-    "ethers": "^6.13.2", 
-    "axios": "^1.7.7", 
-    "zod": "^3.23.8", 
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "lint": "eslint . --max-warnings=0",
+    "propose:eth": "tsx src/proposeTransfer.ts",
+    "propose:erc20": "tsx src/proposeErc20.ts",
+    "opa:test": "opa test ../treasury-policies -v",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@safe-global/protocol-kit": "^5.0.1",
+    "@safe-global/api-kit": "^3.0.2",
+    "ethers": "^6.13.2",
+    "axios": "^1.7.7",
+    "zod": "^3.23.8",
   "dotenv": "^16.4.5",
   "yargs": "^17.7.2"
-  }, 
-  "devDependencies": { 
-    
-    "@types/node": "^22.15.3", 
-    "eslint": "^9.29.0", 
-    "tsx": "^4.19.2", 
-    "typescript": "^5.6.3" 
-  } 
-} 
+  },
+  "devDependencies": {
+
+    "@types/node": "^22.15.3",
+    "eslint": "^9.29.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^1.6.0"
+  }
+}
  
  

--- a/packages/treasury-cli/src/bignumber.ts
+++ b/packages/treasury-cli/src/bignumber.ts
@@ -1,0 +1,5 @@
+import { BigNumberish, ethers } from "ethers";
+
+export const bnToString = (value: BigNumberish): string => ethers.toBigInt(value).toString();
+
+export const ethToWei = (value: BigNumberish): string => ethers.parseEther(bnToString(value)).toString();

--- a/packages/treasury-cli/src/proposeErc20.ts
+++ b/packages/treasury-cli/src/proposeErc20.ts
@@ -1,27 +1,67 @@
 import "dotenv/config";
-import { getProvider, getSigner, getSafeSdk, getSafeService, getThresholdAndApprovals } from "./safe.js";
-import { evaluatePolicy, logDecision } from "./opa.js";
-import { PolicyInput } from "./types.js";
-import { ethers } from "ethers";
+import { ethers, BigNumberish } from "ethers";
+import { fileURLToPath } from "url";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { getProvider, getSigner, getSafeSdk, getSafeService, getThresholdAndApprovals } from "./safe.js";
+import { evaluatePolicy, logDecision } from "./opa.js";
+import { PolicyInput, Role, FundKind } from "./types.js";
+import { bnToString } from "./bignumber.js";
 
-const ERC20_ABI = ["function transfer(address to,uint256 amount) returns (bool)"];
+export const ERC20_ABI = ["function transfer(address to,uint256 amount) returns (bool)"];
 
-const y = yargs(hideBin(process.argv))
+export interface Erc20Args {
+  safe: string;
+  token: string;
+  to: string;
+  amount: BigNumberish;
+  role: Role;
+}
+
+export interface Erc20Meta {
+  chainId: number;
+  fundKind: FundKind;
+  threshold: number;
+  approvals: number;
+  initiator: string;
+  now?: Date;
+}
+
+export const buildErc20PolicyInput = (args: Erc20Args, meta: Erc20Meta): { input: PolicyInput; data: string } => {
+  const now = meta.now ?? new Date();
+  const iface = new ethers.Interface(ERC20_ABI);
+  const data = iface.encodeFunctionData("transfer", [args.to, bnToString(args.amount)]);
+  const input: PolicyInput = {
+    initiator: { address: meta.initiator, role: Role.parse(args.role) },
+    tx: {
+      safe: args.safe.toLowerCase(),
+      to: args.token.toLowerCase(),
+      valueWei: "0",
+      token: args.token.toLowerCase(),
+      data,
+    },
+    context: {
+      chainId: meta.chainId,
+      fundKind: FundKind.parse(meta.fundKind),
+      utcHour: now.getUTCHours(),
+      weekday: now.getUTCDay(),
+      threshold: meta.threshold,
+      currentApprovals: meta.approvals,
+    },
+  };
+  return { input, data };
+};
+
+const cli = yargs<Erc20Args>(hideBin(process.argv))
   .option("safe", { type: "string", default: process.env.DEFAULT_SAFE_ADDRESS, demandOption: true })
   .option("token", { type: "string", demandOption: true })
   .option("to", { type: "string", demandOption: true })
   .option("amount", { type: "string", demandOption: true, describe: "Token units (raw, not decimals-adjusted)" })
-  .option("role", {
-    type: "string",
-    choices: ["CFO", "FINANCE_OPS", "GRANTS_LEAD", "RND_LEAD", "EXEC", "VIEWER"],
-    default: "FINANCE_OPS",
-  })
+  .option("role", { type: "string", choices: Role.options, default: "FINANCE_OPS" })
   .strict();
 
-(async () => {
-  const args = await y.argv;
+const main = async () => {
+  const args = await cli.parse();
   const { RPC_URL, CHAIN_ID, SAFE_TX_SERVICE_URL, SIGNER_PK, OPA_URL, OPA_DECISIONS_LOG, FUND_KIND } = process.env;
 
   if (!RPC_URL || !CHAIN_ID || !SIGNER_PK || !OPA_URL || !FUND_KIND || !SAFE_TX_SERVICE_URL) {
@@ -30,34 +70,19 @@ const y = yargs(hideBin(process.argv))
 
   const provider = getProvider(RPC_URL);
   const signer = getSigner(provider, SIGNER_PK);
-  const token = new ethers.Contract(args.token!, ERC20_ABI, provider);
-  const data = token.interface.encodeFunctionData("transfer", [args.to!, args.amount!]);
-
-  const safe = await getSafeSdk(args.safe!, signer);
+  const safe = await getSafeSdk(args.safe, signer);
   const service = getSafeService(SAFE_TX_SERVICE_URL, Number(CHAIN_ID));
-  const { threshold, approvals } = await getThresholdAndApprovals(service, args.safe!);
+  const { threshold, approvals } = await getThresholdAndApprovals(service, args.safe);
 
-  const now = new Date();
-  const input: PolicyInput = {
-    initiator: { address: await signer.getAddress(), role: args.role as any },
-    tx: {
-      safe: args.safe!.toLowerCase(),
-      to: args.token!.toLowerCase(),
-      valueWei: "0",
-      token: args.token!.toLowerCase(),
-      data,
-    },
-    context: {
-      chainId: Number(CHAIN_ID),
-      fundKind: FUND_KIND as any,
-      utcHour: now.getUTCHours(),
-      weekday: now.getUTCDay(),
-      threshold,
-      currentApprovals: approvals,
-    },
-  };
+  const { input, data } = buildErc20PolicyInput(args, {
+    chainId: Number(CHAIN_ID),
+    fundKind: FundKind.parse(FUND_KIND),
+    threshold,
+    approvals,
+    initiator: await signer.getAddress(),
+  });
 
-  const decision = await evaluatePolicy(OPA_URL!, input);
+  const decision = await evaluatePolicy(OPA_URL, input);
   await logDecision(OPA_DECISIONS_LOG, { input, decision });
 
   if (!decision.allow) {
@@ -65,17 +90,24 @@ const y = yargs(hideBin(process.argv))
     process.exit(2);
   }
 
-  const txData = { to: args.token!, data, value: "0" };
+  const txData = { to: args.token, data, value: "0" };
   const safeTx = await safe.createTransaction({ transactions: [txData] });
   const sender = await signer.getAddress();
   const safeTxHash = await safe.getTransactionHash(safeTx);
   const senderSig = await signer.signMessage(ethers.getBytes(safeTxHash));
   const response = await service.proposeTransaction({
-    safeAddress: args.safe!,
+    safeAddress: args.safe,
     safeTransactionData: safeTx.data,
     safeTxHash,
     senderAddress: sender,
     senderSignature: senderSig,
   });
   console.log("✅ Propuesta enviada al Safe Tx Service:", response);
-})();
+};
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
+  main();
+}
+
+export default main;

--- a/packages/treasury-cli/src/types.ts
+++ b/packages/treasury-cli/src/types.ts
@@ -1,33 +1,38 @@
-import { z } from "zod"; 
- 
-export const PolicyInput = z.object({ 
-  // who is initiating / proposing off-chain 
-  initiator: z.object({ 
-    address: z.string().toLowerCase(), 
-    role: z.enum(["CFO", "FINANCE_OPS", "GRANTS_LEAD", "RND_LEAD", 
-"EXEC", "VIEWER"]).optional() 
-  }), 
-  // safe and transaction 
-  tx: z.object({ 
-    safe: z.string().toLowerCase(), 
-    to: z.string().toLowerCase(), 
-    valueWei: z.string(),          // string to avoid bigint issues 
-    token: z.string().toLowerCase().nullable(), // null for native 
-    data: z.string().optional(), 
-  operation: z.number().int().optional().default(0), // 0 CALL, 1 DELEGATECALL
-  }), 
-  context: z.object({ 
-    chainId: z.number().int(), 
-    fundKind: z.enum(["operativo", "grants", "rnd"]), 
-    utcHour: z.number().min(0).max(23), 
-    weekday: z.number().min(0).max(6), 
-    // dynamic values gathered from Safe service 
-    threshold: z.number().int().positive(), 
-    currentApprovals: z.number().int().nonnegative() 
-  }) 
-}); 
- 
-export type PolicyInput = z.infer<typeof PolicyInput>; 
+import { z } from "zod";
+
+export const Role = z.enum(["CFO", "FINANCE_OPS", "GRANTS_LEAD", "RND_LEAD", "EXEC", "VIEWER"]);
+export type Role = z.infer<typeof Role>;
+
+export const FundKind = z.enum(["operativo", "grants", "rnd"]);
+export type FundKind = z.infer<typeof FundKind>;
+
+export const PolicyInput = z.object({
+  // who is initiating / proposing off-chain
+  initiator: z.object({
+    address: z.string().toLowerCase(),
+    role: Role.optional(),
+  }),
+  // safe and transaction
+  tx: z.object({
+    safe: z.string().toLowerCase(),
+    to: z.string().toLowerCase(),
+    valueWei: z.string(), // string to avoid bigint issues
+    token: z.string().toLowerCase().nullable(), // null for native
+    data: z.string().optional(),
+    operation: z.number().int().optional().default(0), // 0 CALL, 1 DELEGATECALL
+  }),
+  context: z.object({
+    chainId: z.number().int(),
+    fundKind: FundKind,
+    utcHour: z.number().min(0).max(23),
+    weekday: z.number().min(0).max(6),
+    // dynamic values gathered from Safe service
+    threshold: z.number().int().positive(),
+    currentApprovals: z.number().int().nonnegative(),
+  }),
+});
+
+export type PolicyInput = z.infer<typeof PolicyInput>;
 export type PolicyDecision = { 
 allow: boolean; 
 reasons?: string[]; 

--- a/packages/treasury-cli/test/bignumber.test.ts
+++ b/packages/treasury-cli/test/bignumber.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { bnToString, ethToWei } from "../src/bignumber.js";
+
+describe("BigNumberish helpers", () => {
+  it("bnToString normalizes numbers", () => {
+    expect(bnToString(1)).toBe("1");
+    expect(bnToString("2")).toBe("2");
+    expect(bnToString(3n)).toBe("3");
+  });
+
+  it("ethToWei converts to wei", () => {
+    expect(ethToWei(1)).toBe("1000000000000000000");
+    expect(ethToWei("2")).toBe("2000000000000000000");
+  });
+});

--- a/packages/treasury-cli/test/proposeErc20.test.ts
+++ b/packages/treasury-cli/test/proposeErc20.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildErc20PolicyInput, Erc20Args, ERC20_ABI } from "../src/proposeErc20.js";
+import { ethers } from "ethers";
+
+const meta = {
+  chainId: 1,
+  fundKind: "operativo" as const,
+  threshold: 1,
+  approvals: 0,
+  initiator: "0xInitiator",
+  now: new Date("2024-01-01T00:00:00Z"),
+};
+
+describe("buildErc20PolicyInput", () => {
+  it("creates policy input and encodes data", () => {
+    const args: Erc20Args = {
+      safe: "0xSaFe",
+      token: "0xToken",
+      to: "0xRecipient",
+      amount: "5",
+      role: "CFO",
+    };
+    const { input, data } = buildErc20PolicyInput(args, meta);
+    const iface = new ethers.Interface(ERC20_ABI);
+    expect(data).toBe(
+      iface.encodeFunctionData("transfer", ["0xRecipient", "5"])
+    );
+    expect(input.tx.token).toBe("0xtoken");
+    expect(input.tx.to).toBe("0xtoken");
+    expect(input.initiator.role).toBe("CFO");
+  });
+});

--- a/packages/treasury-cli/test/proposeTransfer.test.ts
+++ b/packages/treasury-cli/test/proposeTransfer.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildTransferPolicyInput, TransferArgs } from "../src/proposeTransfer.js";
+
+const meta = {
+  chainId: 1,
+  fundKind: "operativo" as const,
+  threshold: 2,
+  approvals: 1,
+  initiator: "0xInitiator",
+  now: new Date("2024-01-01T00:00:00Z"),
+};
+
+describe("buildTransferPolicyInput", () => {
+  it("creates policy input", () => {
+    const args: TransferArgs = {
+      safe: "0xSaFe",
+      to: "0xTo",
+      amountEth: 1,
+      note: "",
+      role: "CFO",
+    };
+    const input = buildTransferPolicyInput(args, meta);
+    expect(input.tx.valueWei).toBe("1000000000000000000");
+    expect(input.tx.safe).toBe("0xsafe");
+    expect(input.tx.to).toBe("0xto");
+    expect(input.context.chainId).toBe(1);
+    expect(input.initiator.role).toBe("CFO");
+  });
+});

--- a/packages/treasury-cli/tsconfig.json
+++ b/packages/treasury-cli/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true, 
     "types": ["node"] 
   }, 
-  "include": ["src/**/*.ts"] 
-} 
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
  
  


### PR DESCRIPTION
## Summary
- refactor treasury transfer and ERC20 proposal scripts with strong typing and BigNumberish helpers
- expose policy input builders and add unit tests for CLI helpers

## Testing
- `pnpm test --filter @repo/treasury-cli` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae33b708d88326a401e35113468f90