### PR TITLE
feat(ui): type forwardRef and readonly props

### DIFF
--- a/packages/ui/dist/button.d.ts
+++ b/packages/ui/dist/button.d.ts
@@ -1,2 +1,4 @@
-import React from 'react';
-export declare function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>): import("react/jsx-runtime").JSX.Element;
+import React from "react";
+export declare const Button: React.ForwardRefExoticComponent<
+  Readonly<React.ButtonHTMLAttributes<HTMLButtonElement>> & React.RefAttributes<HTMLButtonElement>
+>;

--- a/packages/ui/dist/button.js
+++ b/packages/ui/dist/button.js
@@ -1,4 +1,16 @@
 import { jsx as _jsx } from "react/jsx-runtime";
-export function Button(props) {
-    return _jsx("button", { ...props, style: { padding: '8px 12px', borderRadius: 8, border: '1px solid #ddd', background: '#fff', cursor: 'pointer', ...(props.style || {}) } });
-}
+import React from "react";
+export const Button = React.forwardRef(function Button(props, ref) {
+  return _jsx("button", {
+    ref: ref,
+    ...props,
+    style: {
+      padding: "8px 12px",
+      borderRadius: 8,
+      border: "1px solid #ddd",
+      background: "#fff",
+      cursor: "pointer",
+      ...(props.style || {}),
+    },
+  });
+});

--- a/packages/ui/dist/card.d.ts
+++ b/packages/ui/dist/card.d.ts
@@ -1,5 +1,8 @@
-import React from 'react';
-export declare function Card({ title, children }: {
+import React from "react";
+export declare const Card: React.ForwardRefExoticComponent<
+  Readonly<{
     title?: string;
     children?: React.ReactNode;
-}): import("react/jsx-runtime").JSX.Element;
+  }> &
+    React.RefAttributes<HTMLDivElement>
+>;

--- a/packages/ui/dist/card.js
+++ b/packages/ui/dist/card.js
@@ -1,4 +1,16 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-export function Card({ title, children }) {
-    return (_jsxs("div", { style: { border: '1px solid #eee', borderRadius: 12, background: '#fff' }, children: [title && _jsx("div", { style: { padding: '10px 14px', borderBottom: '1px solid #eee', fontWeight: 600 }, children: title }), _jsx("div", { style: { padding: '10px 14px' }, children: children })] }));
-}
+import React from "react";
+export const Card = React.forwardRef(function Card({ title, children }, ref) {
+  return _jsxs("div", {
+    ref: ref,
+    style: { border: "1px solid #eee", borderRadius: 12, background: "#fff" },
+    children: [
+      title &&
+        _jsx("div", {
+          style: { padding: "10px 14px", borderBottom: "1px solid #eee", fontWeight: 600 },
+          children: title,
+        }),
+      _jsx("div", { style: { padding: "10px 14px" }, children: children }),
+    ],
+  });
+});

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,5 +1,20 @@
-import React from 'react';
+import React from "react";
 
-export function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return <button {...props} style={{ padding: '8px 12px', borderRadius: 8, border: '1px solid #ddd', background: '#fff', cursor: 'pointer', ...(props.style||{}) }} />;
-}
+type ButtonProps = Readonly<React.ButtonHTMLAttributes<HTMLButtonElement>>;
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
+  return (
+    <button
+      ref={ref}
+      {...props}
+      style={{
+        padding: "8px 12px",
+        borderRadius: 8,
+        border: "1px solid #ddd",
+        background: "#fff",
+        cursor: "pointer",
+        ...(props.style || {}),
+      }}
+    />
+  );
+});

--- a/packages/ui/src/card.tsx
+++ b/packages/ui/src/card.tsx
@@ -1,12 +1,22 @@
-import React from 'react';
+import React from "react";
 
-export function Card({ title, children }: { title?: string; children?: React.ReactNode }) {
+type CardProps = Readonly<{
+  title?: string;
+  children?: React.ReactNode;
+}>;
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(function Card(
+  { title, children },
+  ref
+) {
   return (
-    <div style={{ border: '1px solid #eee', borderRadius: 12, background: '#fff' }}>
-      {title && <div style={{ padding: '10px 14px', borderBottom: '1px solid #eee', fontWeight: 600 }}>{title}</div>}
-      <div style={{ padding: '10px 14px' }}>
-        {children}
-      </div>
+    <div ref={ref} style={{ border: "1px solid #eee", borderRadius: 12, background: "#fff" }}>
+      {title && (
+        <div style={{ padding: "10px 14px", borderBottom: "1px solid #eee", fontWeight: 600 }}>
+          {title}
+        </div>
+      )}
+      <div style={{ padding: "10px 14px" }}>{children}</div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
- use typed forwardRef with readonly props for Button
- apply typed forwardRef with readonly props for Card

## Testing
- `npx eslint packages/ui/src/button.tsx packages/ui/src/card.tsx -f json`
- `pnpm --filter @gnew/ui build`


------
https://chatgpt.com/codex/tasks/task_e_68ae33c8fc2083268e648905d7c2e437