### PR TITLE
Add remappings and smoke tests for core contracts

### DIFF
--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,2 +1,2 @@
-@openzeppelin/=node_modules/@openzeppelin/
+@openzeppelin/=../../node_modules/@openzeppelin/
 forge-std/=lib/forge-std/src/

--- a/packages/contracts/test/GnewGovToken.t.sol
+++ b/packages/contracts/test/GnewGovToken.t.sol
@@ -38,37 +38,14 @@ contract GnewGovTokenTest is Test {
         gov.transfer(user, 1); 
     } 
  
-    function testFaucetCooldown() public { 
-        // default chainid in foundry local is testnet-like; faucet 
-allowed 
-        vm.prank(user); 
-        gov.faucet(); 
-        assertEq(gov.balanceOf(user), 5e18); 
-        vm.prank(user); 
-        vm.expectRevert(bytes("faucet:cooldown")); 
-        gov.faucet(); 
-    } 
-} 
- 
-/packages/contracts/foundry.toml (añade snapshot y gas report) 
-[profile.default] 
-src = "src" 
-out = "out" 
-test = "test" 
-libs = ["lib"] 
-solc_version = "0.8.24" 
-evm_version = "paris" 
-optimizer = true 
-optimizer_runs = 200 
-fs_permissions = [{ access = "read", path = "./"}] 
-gas_reports = ["GnewGovToken"] 
- 
-remappings = [ 
-  "@openzeppelin/=../../node_modules/@openzeppelin/", 
-  "forge-std/=lib/forge-std/src/" 
-] 
- 
-/packages/contracts/.gas-snapshot (generado por forge snapshot; se actualizará en tu 
-entorno) 
-# Se generará automáticamente al ejecutar `pnpm --filter 
-@gnew/contracts snapshot` 
+    function testFaucetCooldown() public {
+        // default chainid in foundry local is testnet-like; faucet
+allowed
+        vm.prank(user);
+        gov.faucet();
+        assertEq(gov.balanceOf(user), 5e18);
+        vm.prank(user);
+        vm.expectRevert(bytes("faucet:cooldown"));
+        gov.faucet();
+    }
+}

--- a/packages/contracts/test/GnewGovernor.t.sol
+++ b/packages/contracts/test/GnewGovernor.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {GnewGovernor} from "../src/governance/GnewGovernor.sol";
+import {ReputationScore} from "../src/reputation/ReputationScore.sol";
+import {TokenVotesMock} from "../src/mocks/TokenVotesMock.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+
+contract GnewGovernorTest is Test {
+    TokenVotesMock token;
+    ReputationScore rep;
+    GnewGovernor governor;
+
+    address admin = address(0xA11CE);
+    address voter = address(0xB0B);
+
+    function setUp() public {
+        token = new TokenVotesMock();
+        token.mint(voter, 100e18);
+        vm.prank(voter);
+        token.delegate(voter);
+
+        rep = new ReputationScore(admin, admin);
+        vm.prank(admin);
+        rep.setScore(voter, 100);
+        vm.prank(voter);
+        rep.delegate(voter);
+
+        vm.roll(2); // ensure votes are checkpointed
+
+        governor = new GnewGovernor(
+            IVotes(address(token)),
+            IVotes(address(rep)),
+            7000,
+            3000,
+            100,
+            1,
+            10,
+            0
+        );
+    }
+
+    function testProposeAndVote() public {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        targets[0] = address(0);
+        values[0] = 0;
+        calldatas[0] = "";
+
+        vm.prank(voter);
+        uint256 proposalId = governor.propose(targets, values, calldatas, "test");
+
+        vm.roll(block.number + 1); // start voting
+
+        vm.prank(voter);
+        governor.castVote(proposalId, 1); // For
+
+        vm.roll(block.number + 10); // end voting period
+        assertEq(uint256(governor.state(proposalId)), 4); // Succeeded
+    }
+}

--- a/packages/contracts/test/ReputationScore.t.sol
+++ b/packages/contracts/test/ReputationScore.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {ReputationScore} from "../src/reputation/ReputationScore.sol";
+
+contract ReputationScoreTest is Test {
+    ReputationScore rep;
+    address admin = address(0xA11CE);
+    address user = address(0xB0B);
+
+    function setUp() public {
+        rep = new ReputationScore(admin, admin);
+    }
+
+    function testSetScoreAndVotes() public {
+        vm.prank(admin);
+        rep.setScore(user, 42);
+        vm.prank(user);
+        rep.delegate(user);
+        vm.roll(block.number + 1);
+        assertEq(rep.getVotes(user), 42);
+        assertEq(rep.totalScore(), 42);
+    }
+}

--- a/packages/contracts/test/StakingManager.t.sol
+++ b/packages/contracts/test/StakingManager.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {StakingManager} from "../src/staking/StakingManager.sol";
+import {TokenVotesMock} from "../src/mocks/TokenVotesMock.sol";
+
+contract StakingManagerTest is Test {
+    TokenVotesMock token;
+    StakingManager manager;
+    address admin = address(0xA11CE);
+    address operator = address(0xB0B);
+    address delegator = address(0xC0DE);
+
+    function setUp() public {
+        token = new TokenVotesMock();
+        token.mint(delegator, 100e18);
+        manager = new StakingManager(address(token), admin, admin, 1e18, 1, 0);
+        vm.prank(delegator);
+        token.approve(address(manager), type(uint256).max);
+    }
+
+    function testDelegateUndelegateClaim() public {
+        vm.prank(delegator);
+        manager.delegate(operator, 10e18);
+        (uint256 activeShares, ) = manager.position(operator, delegator);
+        assertEq(activeShares, 10e18);
+
+        vm.prank(delegator);
+        manager.undelegate(operator, 10e18);
+        (activeShares, StakingManager.Unbonding[] memory unbonds) = manager.position(operator, delegator);
+        assertEq(activeShares, 0);
+        assertEq(unbonds.length, 1);
+
+        vm.warp(block.timestamp + 2);
+        vm.prank(delegator);
+        manager.claim(operator, 0);
+        assertEq(token.balanceOf(delegator), 100e18);
+    }
+}


### PR DESCRIPTION
## Summary
- update remappings to point at workspace OpenZeppelin packages
- add Foundry smoke tests for governor, staking, and reputation modules
- clean existing governance token test

## Testing
- `forge test` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae33d83df883269a88af7ac19407ee