### PR TITLE
docs: add ADRs and contributing guide

### DIFF
--- a/docs/adr/0001-oz-remappings.md
+++ b/docs/adr/0001-oz-remappings.md
@@ -1,0 +1,11 @@
+# ADR 0001: OpenZeppelin Remappings
+
+## Context
+OpenZeppelin libraries are used across contracts. Import paths vary between tools and can lead to brittle references.
+
+## Decision
+Define a single `openzeppelin/` remapping in tooling (Foundry, Hardhat) so imports use `import "openzeppelin/contracts/..."`.
+
+## Consequences
+- Simplified imports and migrations between tools.
+- Upgrades require updating the remapping only once.

--- a/docs/adr/0002-typechain.md
+++ b/docs/adr/0002-typechain.md
@@ -1,0 +1,11 @@
+# ADR 0002: TypeChain for Contract Typings
+
+## Context
+Interacting with contracts in TypeScript previously relied on generic `ethers` types, increasing runtime errors.
+
+## Decision
+Generate contract bindings with TypeChain during builds. Projects import the generated factories and types instead of raw ABIs.
+
+## Consequences
+- Safer contract calls with compile‑time checks.
+- Build step requires running TypeChain when ABIs change.

--- a/docs/adr/0003-readonly-props.md
+++ b/docs/adr/0003-readonly-props.md
@@ -1,0 +1,11 @@
+# ADR 0003: Readonly Component Props
+
+## Context
+Mutable component props in React/TS lead to unintended side effects and unclear ownership.
+
+## Decision
+Declare props interfaces with `readonly` fields by default. Mutability must be explicit.
+
+## Consequences
+- Components become easier to reason about.
+- Passing mutable objects requires wrapping or refactoring.

--- a/docs/adr/0004-secret-management.md
+++ b/docs/adr/0004-secret-management.md
@@ -1,0 +1,11 @@
+# ADR 0004: Secret Management
+
+## Context
+Hard‑coding credentials or using plain `.env` files risks leaks in repositories and logs.
+
+## Decision
+Store secrets in dedicated secret managers or encrypted `.env` files. CI pipelines load them at runtime without committing values.
+
+## Consequences
+- Reduces risk of credential exposure.
+- Requires provisioning access for developers and CI systems.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,6 @@
+# Guía de Contribución
+
+## Patrones de refactor
+- **Ternarios → helpers**: extrae condicionales complejos a funciones descriptivas.
+- **Optional chaining**: usa `?.` para navegar objetos anidados evitando errores por `undefined`.
+- **Validación runtime**: valida entradas con esquemas o asserts antes de usar los datos.

--- a/packages/checkout-react/README.md
+++ b/packages/checkout-react/README.md
@@ -10,3 +10,6 @@ Componentes React listos para usar con `@gnew/checkout-sdk`.
 > Sin dependencias externas (usa estilos inline). Compatible con Vite/Next.
 
 
+
+---
+Más decisiones en [docs/adr](../../docs/adr/) y guía en [docs/contributing.md](../../docs/contributing.md).

--- a/packages/checkout-sdk/README.md
+++ b/packages/checkout-sdk/README.md
@@ -69,3 +69,6 @@ SubscriptionsClient.listDue() (para paneles/diagnóstico)
 }
 
 
+
+---
+Más decisiones en [docs/adr](../../docs/adr/) y guía en [docs/contributing.md](../../docs/contributing.md).

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -58,3 +58,6 @@ Riesgos & Controles
 "typescript": "^5.5.4" 
 } 
 } 
+
+---
+Más decisiones en [docs/adr](../../docs/adr/) y guía en [docs/contributing.md](../../docs/contributing.md).

--- a/packages/contracts/addressbook/README.md
+++ b/packages/contracts/addressbook/README.md
@@ -60,3 +60,6 @@ const list = json.deployments.filter((x) => x.name === name &&
 x.chainId === chainId); 
 return list.at(-1); 
 } 
+
+---
+Más decisiones en [docs/adr](../../../docs/adr/) y guía en [docs/contributing.md](../../../docs/contributing.md).

--- a/packages/treasury-policies/README.md
+++ b/packages/treasury-policies/README.md
@@ -46,3 +46,6 @@ opa test . -v ---
     } 
   } 
 } 
+
+---
+Más decisiones en [docs/adr](../../docs/adr/) y guía en [docs/contributing.md](../../docs/contributing.md).

--- a/packages/treasury-safe/README.md
+++ b/packages/treasury-safe/README.md
@@ -29,3 +29,6 @@ network"
 } 
  
  
+
+---
+Más decisiones en [docs/adr](../../docs/adr/) y guía en [docs/contributing.md](../../docs/contributing.md).


### PR DESCRIPTION
## Summary
- add ADRs for OpenZeppelin remappings, TypeChain usage, readonly props, and secret management
- document refactor patterns in contributing guide
- link package READMEs to ADR and contributing docs

## Testing
- `pre-commit run --files docs/adr/0001-oz-remappings.md docs/adr/0002-typechain.md docs/adr/0003-readonly-props.md docs/adr/0004-secret-management.md docs/contributing.md packages/checkout-react/README.md packages/checkout-sdk/README.md packages/contracts/README.md packages/contracts/addressbook/README.md packages/treasury-policies/README.md packages/treasury-safe/README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68ae341f0d1c8326a9eec5d15d6c3908