### PR TITLE
fix(web): refactor state and ternaries

### DIFF
--- a/apps/web/components/AISuggestions.tsx
+++ b/apps/web/components/AISuggestions.tsx
@@ -9,6 +9,7 @@ export default function AISuggestions({ conversationId, messages, lang = "es" }:
   const [loading, setLoading] = useState(false);
   const [error, setErr] = useState<string | null>(null);
   const [data, setData] = useState<Awaited<ReturnType<typeof callSummarize>> | null>(null);
+  const [query, setQuery] = useState<string>("");
 
   const canRun = useMemo(() => messages && messages.length > 0, [messages]);
 
@@ -52,14 +53,22 @@ export default function AISuggestions({ conversationId, messages, lang = "es" }:
         <h2 id="ai-suggestions-title" className="text-lg md:text-xl font-semibold">
           {texts.heading}
         </h2>
-        <button
-          onClick={run}
-          disabled={!canRun || loading}
-          className="px-3 py-2 rounded-xl bg-black text-white disabled:opacity-50"
-          aria-busy={loading}
-        >
-          {buttonLabel}
-        </button>
+        <div className="flex items-center gap-2">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={isEs ? "Pregunta" : "Query"}
+            className="px-2 py-1 rounded-lg border border-gray-300"
+          />
+          <button
+            onClick={run}
+            disabled={!canRun || loading}
+            className="px-3 py-2 rounded-xl bg-black text-white disabled:opacity-50"
+            aria-busy={loading}
+          >
+            {buttonLabel}
+          </button>
+        </div>
       </div>
 
       {error && (

--- a/apps/web/components/VariantsPanel.tsx
+++ b/apps/web/components/VariantsPanel.tsx
@@ -11,8 +11,17 @@ import {
 LineChart, Line, CartesianGrid, 
 } from "recharts"; 
  
-type VariantKey = "one_person_one_vote" | "token_weighted" | 
-"quadratic_voting"; 
+type VariantKey = "one_person_one_vote" | "token_weighted" | "quadratic_voting";
+
+function computeWeight(i: number) {
+  if (i < 12) return 10;
+  return i < 40 ? 3 : 1;
+}
+
+function computeLabel(v: VariantKey) {
+  if (v === "one_person_one_vote") return "1p=1v";
+  return v === "token_weighted" ? "Token-weighted" : "Quadratic";
+}
  
 export default function VariantsPanel({ demo = false }: Readonly<{ demo?:
 boolean }>) {
@@ -30,13 +39,13 @@ boolean }>) {
       { id: "C", title: "Opción C" }, 
       { id: "D", title: "Opción D" }, 
     ]; 
-    const voters = Array.from({ length: 120 }, (_, i) => ({ 
-      id: `v${i + 1}`, 
+    const voters = Array.from({ length: 120 }, (_, i) => ({
+      id: `v${i + 1}`,
       // 10% whales (peso 10), 28% mid (peso 3), resto 1
-      weight: i < 12 ? 10 : i < 40 ? 3 : 1,
-      credits: 9, 
-      segment: i < 40 ? "core" : "new", 
-    })); 
+      weight: computeWeight(i),
+      credits: 9,
+      segment: i < 40 ? "core" : "new",
+    }));
     const ballots = voters.map((v, i) => { 
       // preferencias sintéticas: core prefiere A/B, newcomers C/D 
       const s: Record<string, number> = { A: 0, B: 0, C: 0, D: 0 }; 
@@ -208,20 +217,16 @@ name="Sensibilidad Sybil (p.p.)" />
                 </tr> 
               </thead> 
               <tbody> 
-                {data.summary.map((s: any) => ( 
-                  <tr key={s.variant} className="border-t"> 
-                    <td className="p-2">{s.variant === 
-"one_person_one_vote" ? "1p=1v" : s.variant === "token_weighted" ? 
-"Token-weighted" : "Quadratic"}</td> 
-                    <td className="p-2 text-right"> 
-                      {s.result.winner} 
-                    </td> 
-                    <td className="p-2 
-text-right">{(s.metrics.decisiveMargin * 100).toFixed(1)}</td> 
-                    <td className="p-2 
-text-right">{(s.metrics.disagreementRate * 100).toFixed(1)}</td> 
-                  </tr> 
-                ))} 
+                {data.summary.map((s: any) => (
+                  <tr key={s.variant} className="border-t">
+                    <td className="p-2">{computeLabel(s.variant)}</td>
+                    <td className="p-2 text-right">
+                      {s.result.winner}
+                    </td>
+                    <td className="p-2 text-right">{(s.metrics.decisiveMargin * 100).toFixed(1)}</td>
+                    <td className="p-2 text-right">{(s.metrics.disagreementRate * 100).toFixed(1)}</td>
+                  </tr>
+                ))}
               </tbody> 
             </table> 
           </div> 

--- a/apps/web/components/missions/WeeklyMissionsBoard.tsx
+++ b/apps/web/components/missions/WeeklyMissionsBoard.tsx
@@ -77,6 +77,8 @@ export const WeeklyMissionsBoard: React.FC = () => {
     fetchMissions();
   }, []);
 
+  const missions = data?.missions ?? [];
+
   if (loading) {
     return (
       <div className="p-4 text-gray-500 animate-pulse">Cargando misiones semanales…</div>
@@ -89,7 +91,7 @@ export const WeeklyMissionsBoard: React.FC = () => {
     );
   }
 
-  if (!data || !data.missions.length) {
+  if (!missions.length) {
     return (
       <div className="p-4 text-gray-500">No hay misiones planificadas para esta semana.</div>
     );
@@ -100,11 +102,11 @@ export const WeeklyMissionsBoard: React.FC = () => {
       <header className="text-center">
         <h2 className="text-2xl font-bold">Misiones de la Semana</h2>
         <p className="text-sm text-gray-500">
-          {formatDate(data.weekStart)} – {formatDate(data.weekEnd)}
+          {formatDate(data?.weekStart ?? "")} – {formatDate(data?.weekEnd ?? "")}
         </p>
       </header>
       <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {data.missions.map((m) => (
+        {missions.map((m) => (
           <li key={m.id} className="bg-white rounded-2xl shadow p-4 flex flex-col justify-between border border-gray-200">
             <div>
               <h3 className="text-lg font-semibold mb-2">{m.title}</h3>


### PR DESCRIPTION
## Summary
- add query state and input to AI suggestions
- refactor voting variant panel ternaries into helper functions
- safeguard weekly missions board with optional chaining

## Testing
- `pnpm exec eslint apps/web/components/AISuggestions.tsx apps/web/components/VariantsPanel.tsx apps/web/components/missions/WeeklyMissionsBoard.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm test --filter @gnew/web` *(fails: vitest not found)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fnode: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af1bca709c8326a406372eae3a7210