### PR TITLE
fix: align tsconfig and replace require with custom error

### DIFF
--- a/packages/contracts/DocHashRegistry.sol
+++ b/packages/contracts/DocHashRegistry.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.24;
 /// @title DocHashRegistry
 /// @notice Registro simple de hashes (SHA-256 como bytes32) vinculados a (docId, version).
 contract DocHashRegistry {
+    error DocHashRegistry__AlreadyRegistered(bytes32 hash);
     struct Record {
         string docId;
         uint256 version;
@@ -18,7 +19,9 @@ contract DocHashRegistry {
 
     /// @dev Registra un hash. Si ya existe, revierte (inmutabilidad).
     function registerDocument(bytes32 hash, string calldata docId, uint256 version) external {
-        require(records[hash].by == address(0), "already_registered");
+        if (records[hash].by != address(0)) {
+            revert DocHashRegistry__AlreadyRegistered(hash);
+        }
         records[hash] = Record({ docId: docId, version: version, by: msg.sender, blockTime: block.timestamp });
         emit Registered(hash, docId, version, msg.sender);
     }

--- a/services/governance/tsconfig.json
+++ b/services/governance/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- use custom error in DocHashRegistry instead of string requires
- align governance service tsconfig module setting with NodeNext resolution

## Testing
- `forge --version` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed 403)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/... 403)*
- `pnpm run compile` *(fails: hardhat not found)*
- `pnpm tsc -p tsconfig.json` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af237842748326b0202c390ae99152